### PR TITLE
Fix p4est without zlib

### DIFF
--- a/deal.II-toolchain/packages/p4est.package
+++ b/deal.II-toolchain/packages/p4est.package
@@ -14,6 +14,12 @@ package_specific_setup () {
         exit 1
     }
 
+    # export zlib if we installed it ourselves
+    if [ ! -z "${ZLIB_DIR}" ]; then
+      LIBS="-L${ZLIB_LIBPATH}"
+      CFLAGS="$CFLAGS -I${ZLIB_INCLUDE}"
+    fi
+
     if test -z "$CFLAGS" -a -z "$P4EST_CFLAGS_FAST" ; then
         export CFLAGS_FAST="-O2"
     else
@@ -81,6 +87,7 @@ package_specific_setup () {
     make -C sc -j${PROCS} > make.output || bdie "Error in make sc"
     make -j${PROCS} >> make.output || bdie "Error in make p4est"
     make install >> make.output || bdie "Error in make install"
+    grep -q "#define P4EST_HAVE_ZLIB" $INSTALL_DEBUG/include/p4est_config.h || bdie "Error: p4est couldn't find zlib"
     echo "DEBUG version installed in $INSTALL_DEBUG"
     echo
     


### PR DESCRIPTION
If zlib is installed as part of candi (or manually by setting ZLIB_*),
pass this info to p4est. It turns out p4est won't work (at least in
debug mode) without having access to zlib. So enforce that too.