### PR TITLE
enable PARPACK support

### DIFF
--- a/deal.II-toolchain/packages/dealii.package
+++ b/deal.II-toolchain/packages/dealii.package
@@ -37,9 +37,13 @@ ${DEAL_CONFOPTS} \
 # arpack
 if [ ! -z "${ARPACK_DIR}" ]; then
     cecho ${INFO} "deal.II: configuration with ARPACK"
+    # We use a recent enough version of arpack, so PARPACK can be enabled
+    # even though it is disabled by default, see 
+    # https://github.com/dealii/dealii/blob/master/cmake/modules/FindARPACK.cmake
     CONFOPTS="\
         ${CONFOPTS} \
         -D DEAL_II_WITH_ARPACK:BOOL=ON \
+        -D DEAL_II_ARPACK_WITH_PARPACK=ON \
         -D ARPACK_DIR=${ARPACK_DIR}"
 fi
 


### PR DESCRIPTION
PARPACK support is disabled inside deal.II by default, but our version
is recent enough.