### PR TITLE
Follow user options

### DIFF
--- a/deal.II-toolchain/packages/dealii.package
+++ b/deal.II-toolchain/packages/dealii.package
@@ -16,7 +16,6 @@ INSTALL_PATH=${ORIG_INSTALL_PATH}/deal.II-${VERSION}
 #Choose general configuration and components of deal.II
 
 CONFOPTS=" \
-${DEAL_CONFOPTS} \
 -D CMAKE_BUILD_TYPE=DebugRelease \
 -D DEAL_II_WITH_MPI:BOOL=ON \
 -D DEAL_II_WITH_THREADS:BOOL=ON \
@@ -29,7 +28,8 @@ ${DEAL_CONFOPTS} \
 -D DEAL_II_FORCE_BUNDLED_BOOST:BOOL=OFF \
 -D DEAL_II_WITH_ZLIB:BOOL=ON \
 -D DEAL_II_WITH_FUNCTIONPARSER:BOOL=ON \
--D DEAL_II_COMPONENT_MESH_CONVERTER:BOOL=ON"
+-D DEAL_II_COMPONENT_MESH_CONVERTER:BOOL=ON \
+${DEAL_CONFOPTS}"
 
 ################################################################################
 # Add additional packages, if present


### PR DESCRIPTION
I used candi to install deal.II on a somewhat particular cluster (CRAY XC40), and for that I needed to set some user options. I created a minimal platform file with only the packages I needed, but its specific options were overwritten by the options set in dealii.package, because user options are interpreted first. This PR fixed my problem, but I have to admit I do not know if there are cases where it breaks other things (are there options that need to be specified first, e.g. compilers? Are some of the listed options necessary, even if the user tries to explicitly disable them?). In my specific case I want to force the bundled boost (the external does not compile cleanly), and I do not want LAPACK and UMFPACK, because I do not need them for my setup, and hard disk space and number of allowed files is scarce.