### PR TITLE
Use tr instead of bash specific command

### DIFF
--- a/deal.II-toolchain/packages/dealii-prepare.package
+++ b/deal.II-toolchain/packages/dealii-prepare.package
@@ -16,7 +16,7 @@ unset option
 unset PACKAGE_NAME
 
 # Transform upper case to lower case.
-PACKAGES_OFF=${PACKAGES_OFF,,}
+PACKAGES_OFF=`echo "$PACKAGES_OFF" | tr '[:upper:]' '[:lower:]'`
 
 if [ ! -z "${PACKAGES_OFF}" ]; then
     cecho ${WARN} "deal.II: forcing package skip for: ${PACKAGES_OFF}"


### PR DESCRIPTION
Related to #29. The same cluster uses bash version 3.2 (released in 2007, the cluster was build last year, but runs Suse Linux Enterprise Server 11). The function to transform upper to lower case that is used by candi was introduced in bash 4.0. According to a google search `tr` is hopefully more standard conform, but again, I have little experience, so I am happy about suggestions how to improve.