### PR TITLE
Allow other compiler wrappers than mpicc

### DIFF
--- a/deal.II-toolchain/packages/parmetis.package
+++ b/deal.II-toolchain/packages/parmetis.package
@@ -25,7 +25,7 @@ package_specific_build() {
     # Secondly build parmetis
     cd ..
     
-    make config prefix=${INSTALL_PATH} shared=1
+    make config prefix=${INSTALL_PATH} shared=1 cc=$CC cxx=$CXX
     quit_if_fail "parmetis make config failed"
     
     make -j${PROCS}


### PR DESCRIPTION
To compile parmetis on a system that does not use `mpicc` as MPI compiler we need to patch its Makefile, because somebody in the parmetis project decided `mpicc` is the only *true* command, and always set `-DMPI_C_COMPILER=mpicc` during the call to cmake :smile:. I also patch the c++ compiler, because parmetis sets this for cmake as well, although it does not seem to use it (but since cmake checks for its existence I get errors if I do not patch it).
There is one complication here: If there are systems that set `$CC` to a compiler that is not able to compile MPI libraries then so far that did work (because Parmetis implicitly used mpicc anyway). This might now break, but I do not quite know what to do about it. I see no other way to allow specifying a different compiler than mpicc.
This resulted out of a discussion in the google group: https://groups.google.com/forum/#!topic/dealii/9IMUhsjSGZ8