### PR TITLE
Use FF as Fortran77 compiler in p4est

### DIFF
--- a/deal.II-toolchain/packages/p4est.package
+++ b/deal.II-toolchain/packages/p4est.package
@@ -68,7 +68,7 @@ package_specific_setup () {
     "${UNPACK_PATH}/${EXTRACTSTO}/configure" --enable-mpi --enable-shared \
         --disable-vtk-binary --without-blas \
         --prefix="$INSTALL_FAST" CFLAGS="$CFLAGS_FAST" \
-        CPPFLAGS="-DSC_LOG_PRIORITY=SC_LP_ESSENTIAL" \
+        CPPFLAGS="-DSC_LOG_PRIORITY=SC_LP_ESSENTIAL" F77="$FF" \
         "$@" > config.output || bdie "Error in configure"
     make -C sc -j${PROCS} > make.output || bdie "Error in make sc"
     make -j${PROCS} >> make.output || bdie "Error in make p4est"
@@ -82,7 +82,7 @@ package_specific_setup () {
     "${UNPACK_PATH}/${EXTRACTSTO}/configure" --enable-debug --enable-mpi --enable-shared \
         --disable-vtk-binary --without-blas \
         --prefix="$INSTALL_DEBUG" CFLAGS="$CFLAGS_DEBUG" \
-        CPPFLAGS="-DSC_LOG_PRIORITY=SC_LP_ESSENTIAL" \
+        CPPFLAGS="-DSC_LOG_PRIORITY=SC_LP_ESSENTIAL" F77="$FF" \
         "$@" > config.output || bdie "Error in configure"
     make -C sc -j${PROCS} > make.output || bdie "Error in make sc"
     make -j${PROCS} >> make.output || bdie "Error in make p4est"

--- a/deal.II-toolchain/platforms/contributed/cray.platform
+++ b/deal.II-toolchain/platforms/contributed/cray.platform
@@ -18,7 +18,6 @@
 #   export CXX=CC
 #   export FC=ftn
 #   export FF=ftn
-#   export F77=ftn
 # 
 ##
 


### PR DESCRIPTION
One more follow-up resulting from #32. candi uses FF as Fortran 77 compiler, while GNU autoconf (as used for p4est) looks for F77. If now FF is set to a correct user-provided compiler, but F77 is empty (then replaced by mpif77) or set to a different value p4est tries to use F77 and might fail. Instead we can explicitly set F77 to the value of FF during configuring p4est. No other included package seems to use autoconf with enabled fortran check so this should be a p4est specific fix.

This change simplifies the configuration for systems with non-default compilers (as can be seen in the cray platform file).