### PR TITLE
hdf5: updated minor version to v1.10.1 from v1.10.0-patch1

### DIFF
--- a/deal.II-toolchain/packages/hdf5.package
+++ b/deal.II-toolchain/packages/hdf5.package
@@ -1,10 +1,10 @@
 MAJORVER=1.10
-MINORVER=0-patch1
+MINORVER=1
 VERSION=${MAJORVER}.${MINORVER}
 NAME=hdf5-${VERSION}
 SOURCE=http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-${MAJORVER}/${NAME}/src/
 PACKING=.tar.gz
-CHECKSUM=9180ff0ef8dc2ef3f61bd37a7404f295
+CHECKSUM=43a2f9466702fb1db31df98ae6677f15
 BUILDCHAIN=autotools
 
 CONFOPTS="--enable-shared --enable-parallel"


### PR DESCRIPTION
Updated minor version to v1.10.1 from v1.10.0-patch1.
Download and build was successful on my system.