### PR TITLE
Add git package

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,20 @@ Note that you probably also want to change the prefix path, or
 the path to ``BLAS`` and ``LAPACK`` in the configuration file
 (see documentation below).
 
+#### Install deal.II on a system without pre-installed git:
+
+```bash
+ wget https://github.com/dealii/candi/archive/master.tar.gz
+ tar -xzf master.tar.gz
+ cd candi-master
+ ./candi.sh
+```
+
+Note that in this case you will need to activate the installation of git by
+uncommenting the line `#PACKAGES="${PACKAGES} once:git"` in
+[candi.cfg](candi.cfg).
+
+
 Advanced Configuration
 ----
 

--- a/candi.cfg
+++ b/candi.cfg
@@ -29,6 +29,16 @@ MIRROR="https://www.ces.clemson.edu/dealii/mirror/"
 DEAL_CONFOPTS=""
 
 PACKAGES="load:dealii-prepare"
+
+# These are system dependencies that are often pre-installed
+#PACKAGES="${PACKAGES} once:zlib"
+#PACKAGES="${PACKAGES} once:bzip2"
+#PACKAGES="${PACKAGES} once:git"
+#PACKAGES="${PACKAGES} once:cmake"
+#PACKAGES="${PACKAGES} once:boost"
+#PACKAGES="${PACKAGES} once:numdiff"
+
+# These packages determine the active components of deal.II
 #PACKAGES="${PACKAGES} once:arpack-ng"
 PACKAGES="${PACKAGES} once:opencascade"
 PACKAGES="${PACKAGES} once:parmetis"

--- a/deal.II-toolchain/packages/git.package
+++ b/deal.II-toolchain/packages/git.package
@@ -1,0 +1,31 @@
+VERSION=2.9.4
+NAME=git-${VERSION}
+SOURCE=https://www.kernel.org/pub/software/scm/git/
+PACKING=.tar.gz
+CHECKSUM=60b7fd85c91ddb783ebd3e948efc5b13
+
+BUILDCHAIN=custom
+
+INSTALL_PATH=${INSTALL_PATH}/${NAME}
+
+package_specific_build () {
+    cp -rf ${UNPACK_PATH}/${EXTRACTSTO}/* .
+    ./configure --prefix=${INSTALL_PATH}
+    quit_if_fail "git configure failed"
+
+    make install
+    quit_if_fail "git make install failed"
+}
+
+package_specific_register () {
+    export PATH=${INSTALL_PATH}/bin:$PATH
+}
+
+package_specific_conf () {
+    # Generate configuration file
+    CONFIG_FILE=${CONFIGURATION_PATH}/${NAME}
+    rm -f $CONFIG_FILE
+    echo "
+export PATH=${INSTALL_PATH}/bin:$PATH
+" >> $CONFIG_FILE
+}


### PR DESCRIPTION
I had to guide a user through the manual installation of git on a cluster to allow them to use candi. I think we can make this easier by providing a git package. Also I think the system dependency packages that are already available should be mentioned in candi.cfg. This way users immediately see what can be additionally installed.