### PR TITLE
Successful build detection

### DIFF
--- a/candi.sh
+++ b/candi.sh
@@ -1072,7 +1072,9 @@ for PACKAGE in ${PACKAGES[@]}; do
     # Most packages extract to a directory named after the package
     default EXTRACTSTO=${NAME}
 
-    if [ ${SKIP} = maybe ] && [ ! -f ${BUILD_PATH}/${NAME}/candi_successful_build ]; then
+    # Check if the package can be set to SKIP:
+    default BUILDDIR=${BUILD_PATH}/${NAME}
+    if [ ${SKIP} = maybe ] && [ ! -f ${BUILDDIR}/candi_successful_build ]; then
         SKIP=false
     fi
     

--- a/deal.II-toolchain/packages/arpack-ng.package
+++ b/deal.II-toolchain/packages/arpack-ng.package
@@ -1,9 +1,8 @@
 VERSION=master
-EXTRACTSTO=arpack-ng
 NAME=arpack-ng.git
-PACKING=git
+EXTRACTSTO=arpack-ng-${VERSION}
 SOURCE=https://github.com/opencollab/
-
+PACKING=git
 BUILDCHAIN=cmake
 
 BUILDDIR=${BUILD_PATH}/arpack-ng-${VERSION}
@@ -26,3 +25,4 @@ package_specific_conf () {
 export ARPACK_DIR=${INSTALL_PATH}
 " >> $CONFIG_FILE
 }
+


### PR DESCRIPTION
Without this patch arpack-ng was not correctly detected for package SKIP. Works now, also for all other packages.