### PR TITLE
Update ubuntu14.platform

### DIFF
--- a/deal.II-toolchain/platforms/supported/ubuntu14.platform
+++ b/deal.II-toolchain/platforms/supported/ubuntu14.platform
@@ -7,7 +7,7 @@
 #   openmpi-bin openmpi-common libopenmpi-dev cmake subversion \
 #   git libblas-dev liblapack-dev libblas3gf liblapack3gf \
 #   libsuitesparse-dev libtool libboost-all-dev \
-#   splint tcl tcl-dev environment-modulesqt4-dev-tools
+#   splint tcl tcl-dev environment-modules qt4-dev-tools
 #
 # Then run candi again.
 ##


### PR DESCRIPTION
#52 Fixed missing space in apt-get argument between environment-modules qt4-dev-tools. Other Ubuntu .platform files look ok.