### PR TITLE
updates linux_cluster_platform

### DIFF
--- a/deal.II-toolchain/platforms/supported/linux_cluster.platform
+++ b/deal.II-toolchain/platforms/supported/linux_cluster.platform
@@ -1,19 +1,21 @@
 # linux
 # 
-# This build script assumes that you have several packages already
-# installed:
-#   automake
-#   autoconf
-#   cmake
-#   mpi
-#   gcc
-#   subversion
-#   git
-#   blas
-#   lapack
+# This build script assumes that you have at least the packages:
+#   automake, autoconf, cmake, gcc, openmpi, blas, lapack, and
+#   git, cmake, zlib and bzip2 and boost
+# installed.
+# 
+# The packages
+#   git, cmake, zlib and bzip2 and boost
+# can be installed with candi by selecting them in the candi.cfg file.
+# 
+# Please note that this platform description is only a hint for
+# dependencies and cannot ensure a successful build. Look into other
+# platform descriptions for further dependencies.
 # 
 ##
 
 #
 # Define the additional packages for this platform.
 #PACKAGES="once:cmake ${PACKAGES}"
+

--- a/deal.II-toolchain/platforms/supported/linux_cluster.platform
+++ b/deal.II-toolchain/platforms/supported/linux_cluster.platform
@@ -2,11 +2,11 @@
 # 
 # This build script assumes that you have at least the packages:
 #   automake, autoconf, cmake, gcc, openmpi, blas, lapack, and
-#   git, cmake, zlib and bzip2 and boost
+#   git, cmake, zlib and bzip2
 # installed.
 # 
 # The packages
-#   git, cmake, zlib and bzip2 and boost
+#   git, cmake, zlib and bzip2
 # can be installed with candi by selecting them in the candi.cfg file.
 # 
 # Please note that this platform description is only a hint for

--- a/deal.II-toolchain/platforms/supported/linux_cluster.platform
+++ b/deal.II-toolchain/platforms/supported/linux_cluster.platform
@@ -16,9 +16,4 @@
 
 #
 # Define the additional packages for this platform.
-PACKAGES="
-once:zlib
-once:bzip2
-once:boost
-${PACKAGES}"
-
+#PACKAGES="once:cmake ${PACKAGES}"


### PR DESCRIPTION
This removes forcing individual packages in the generic `linux_cluster.platform` file.
Individual packages are currently configured in the central `candi.cfg` configuration file.
Resolves the reported issue from here:
https://groups.google.com/forum/#!topic/dealii/QNTdIDgxv1c