### PR TITLE
opencascade patch glibc xlocale.h missing and v0.18.2

### DIFF
--- a/candi.sh
+++ b/candi.sh
@@ -421,6 +421,10 @@ package_unpack() {
         fi
     fi
     
+    # Apply patches
+    cd ${UNPACK_PATH}/${EXTRACTSTO}
+    package_specific_patch
+    
     # Quit with a useful message if something goes wrong
     quit_if_fail "Error unpacking ${FILE_TO_UNPACK}."
     
@@ -1041,6 +1045,7 @@ for PACKAGE in ${PACKAGES[@]}; do
     CONFIGURATION_PATH=${ORIG_CONFIGURATION_PATH}
     
     # Reset package-specific functions
+    package_specific_patch () { true; }
     package_specific_setup () { true; }
     package_specific_build () { true; }
     package_specific_install () { true; }

--- a/deal.II-toolchain/packages/opencascade.package
+++ b/deal.II-toolchain/packages/opencascade.package
@@ -48,6 +48,12 @@ CONFOPTS="-D OCE_INSTALL_PREFIX=${INSTALL_PATH} \
  -D OCE_DISABLE_X11=ON \
 "
 
+package_specific_patch () {
+    cd ${UNPACK_PATH}/${EXTRACTSTO}
+    cecho ${WARN} "applying patch for missing xlocale.h for glibc v2.26 and above"
+    patch -p0 --forward < ${ORIG_DIR}/${PROJECT}/patches/oce-xlocale.patch || true
+}
+
 package_specific_register () {
     export OPENCASCADE_DIR=${INSTALL_PATH}
 }

--- a/deal.II-toolchain/packages/opencascade.package
+++ b/deal.II-toolchain/packages/opencascade.package
@@ -7,7 +7,7 @@ if [ -n "$CANDI_OPENCASCADE_FROM_GIT" ]; then
     # if possible, try to download a release tarball (see below)
     
     # checkout specific release version
-    # VERSION=OCE-0.18.1
+    # VERSION=OCE-0.18.2
     # checkout current development version (master)
     VERSION=master
     
@@ -25,8 +25,10 @@ else
     
     #VERSION=0.17
     #CHECKSUM=f1a89395c4b0d199bea3db62b85f818d
-    VERSION=0.18.1
-    CHECKSUM=2a7597f4243ee1f03245aeeb02d00956
+    #VERSION=0.18.1
+    #CHECKSUM=2a7597f4243ee1f03245aeeb02d00956
+    VERSION=0.18.2
+    CHECKSUM=6dfd68e459e2c62387579888a867281f
 
     NAME=OCE-${VERSION}
     PACKING=.tar.gz

--- a/deal.II-toolchain/patches/oce-xlocale.patch
+++ b/deal.II-toolchain/patches/oce-xlocale.patch
@@ -1,0 +1,17 @@
+diff -u -r -N src.patched/Standard/Standard_CLocaleSentry.hxx src/Standard/Standard_CLocaleSentry.hxx
+--- src.patched/Standard/Standard_CLocaleSentry.hxx	2017-08-11 07:51:11.000000000 +0200
++++ src/Standard/Standard_CLocaleSentry.hxx	2017-10-23 10:53:43.571058000 +0200
+@@ -29,9 +29,11 @@
+     #define HAVE_XLOCALE_H
+   #endif
+ 
+-  //! We check _GNU_SOURCE for glibc extensions here and it is always defined by g++ compiler.
++  //! We check _GNU_SOURCE for glibc <= v2.25 extensions here and it is always defined by g++ compiler.
+   #if defined(_GNU_SOURCE) && !defined(__ANDROID__)
+-    #define HAVE_XLOCALE_H
++    #if defined(__GLIBC__) && __GLIBC__ == 2 && __GLIBC_MINOR__ <= 25
++      #define HAVE_XLOCALE_H
++    #endif
+   #endif
+ #endif // ifndef HAVE_LOCALE_H
+ 


### PR DESCRIPTION
This PR includes:
- a new function `package_specific_patch` to be applied after `package_unpack`
- a patch for opencascade oce v0.18.1 for a missing `xlocale.h` with glibc v2.26
- updates package opencascade to v0.18.2

It resolves #56 .
Tested with glibc 2.25 for oce v0.18.1 and v0.18.2 with the applied patch.
Since I do not have glibc 2.26 I cannot test this.