### PR TITLE
remove python from boost config

### DIFF
--- a/deal.II-toolchain/packages/boost.package
+++ b/deal.II-toolchain/packages/boost.package
@@ -12,7 +12,7 @@ INSTALL_PATH=${INSTALL_PATH}/${NAME}
 
 package_specific_build () {
     cp -rf ${UNPACK_PATH}/${NAME}/* .
-    ./bootstrap.sh --prefix=${INSTALL_PATH}
+    ./bootstrap.sh --prefix=${INSTALL_PATH} --without-libraries=python
     quit_if_fail "boost build ./bootstrap.sh failed"
     
     echo "using mpi ;" > user-config.jam


### PR DESCRIPTION
boost fails to compile with "pyconfig.h: No such file or directory"
because of a broken include path setting inside boost. Instead of
fixing/updating boost (which we can't do because newer boost version are
also not working correctly), just disable the python support inside
boost. We are not using that anyways.