### PR TITLE
add adolc

### DIFF
--- a/candi.cfg
+++ b/candi.cfg
@@ -43,6 +43,7 @@ PACKAGES="load:dealii-prepare"
 #PACKAGES="${PACKAGES} once:numdiff"
 
 # These packages determine the active components of deal.II:
+#PACKAGES="${PACKAGES} once:adolc"
 #PACKAGES="${PACKAGES} once:arpack-ng"
 #PACKAGES="${PACKAGES} once:assimp"
 #PACKAGES="${PACKAGES} once:nanoflann"

--- a/deal.II-toolchain/packages/adolc.package
+++ b/deal.II-toolchain/packages/adolc.package
@@ -13,12 +13,15 @@ if [ -n "$CANDI_ADOLC_FROM_GIT" ]; then
 else
     # download release tarball
 
-    VERSION=2.6.3
-    NAME=ADOL-C-${VERSION}
-    EXTRACTSTO=ADOL-C-${VERSION}
-    SOURCE=https://www.coin-or.org/download/source/ADOL-C/
-    CHECKSUM=f78f67f70d5874830a1ad1c0f54e54f7
-    PACKING=.tgz
+    # 2.6.3 is the latest official release, but is not compatible with
+    # deal.II. For now we have an un-official 2.6.4 RC that we are using.
+
+    #VERSION=2.6.3
+    #NAME=ADOL-C-${VERSION}
+    #EXTRACTSTO=ADOL-C-${VERSION}
+    #SOURCE=https://www.coin-or.org/download/source/ADOL-C/
+    #CHECKSUM=f78f67f70d5874830a1ad1c0f54e54f7
+    #PACKING=.tgz
 
     VERSION=2.6.4-rc1
     NAME=ADOL-C-${VERSION}
@@ -35,7 +38,7 @@ BUILDCHAIN=autotools
 BUILDDIR=${BUILD_PATH}/adolc-${VERSION}
 INSTALL_PATH=${INSTALL_PATH}/adolc-${VERSION}
 
-CONFOPTS=""
+CONFOPTS="--enable-atrig-erf"
 
 package_specific_register () {
     export ADOLC_DIR=${INSTALL_PATH}

--- a/deal.II-toolchain/packages/adolc.package
+++ b/deal.II-toolchain/packages/adolc.package
@@ -38,7 +38,7 @@ BUILDCHAIN=autotools
 BUILDDIR=${BUILD_PATH}/adolc-${VERSION}
 INSTALL_PATH=${INSTALL_PATH}/adolc-${VERSION}
 
-CONFOPTS="--enable-atrig-erf"
+CONFOPTS="--enable-atrig-erf --with-boost=no"
 
 package_specific_register () {
     export ADOLC_DIR=${INSTALL_PATH}

--- a/deal.II-toolchain/packages/adolc.package
+++ b/deal.II-toolchain/packages/adolc.package
@@ -1,0 +1,51 @@
+# use development version?
+#CANDI_ADOLC_FROM_GIT=1
+
+if [ -n "$CANDI_ADOLC_FROM_GIT" ]; then
+    # download git repository
+    VERSION=master
+    EXTRACTSTO=ADOL-C-master
+
+    NAME=adol-c.git
+    PACKING=git
+    SOURCE=https://gitlab.com/adol-c/
+
+else
+    # download release tarball
+
+    VERSION=2.6.3
+    NAME=ADOL-C-${VERSION}
+    EXTRACTSTO=ADOL-C-${VERSION}
+    SOURCE=https://www.coin-or.org/download/source/ADOL-C/
+    CHECKSUM=f78f67f70d5874830a1ad1c0f54e54f7
+    PACKING=.tgz
+
+    VERSION=2.6.4-rc1
+    NAME=ADOL-C-${VERSION}
+    EXTRACTSTO=ADOL-C-${VERSION}
+    SOURCE=https://github.com/tjhei/adol-c/releases/download/v2.6.4-rc1/
+    CHECKSUM=cca27e9579c0c9ab4dd0c1cfa1c44433
+    PACKING=.tar.gz
+fi
+unset CANDI_ADOLC_FROM_GIT
+
+
+BUILDCHAIN=autotools
+
+BUILDDIR=${BUILD_PATH}/adolc-${VERSION}
+INSTALL_PATH=${INSTALL_PATH}/adolc-${VERSION}
+
+CONFOPTS=""
+
+package_specific_register () {
+    export ADOLC_DIR=${INSTALL_PATH}
+}
+
+package_specific_conf () {
+    # Generate configuration file
+    CONFIG_FILE=${CONFIGURATION_PATH}/adolc-${VERSION}
+    rm -f $CONFIG_FILE
+    echo "
+export ADOLC_DIR=${INSTALL_PATH}
+" >> $CONFIG_FILE
+}


### PR DESCRIPTION
    Another optional dependency for deal 9.0.0. It turns out that the latest
    release 2.6.3 is not new enough to work, so I created a temporary
    release tarball on my github. We should switch to the official releases
    after 2.6.4 is out.
    The optional master version compiled from source requires "autoconf"
    installed, so I don't want to use it by default.