### PR TITLE
check if cmake 3.10 used with deal.II v8.5.1 

### DIFF
--- a/deal.II-toolchain/packages/dealii-prepare.package
+++ b/deal.II-toolchain/packages/dealii-prepare.package
@@ -36,6 +36,7 @@ if [ ${DEAL_II_VERSION} = "v8.5.1" ]; then
     if [ ${CMAKE_VER_MAJOR}=="3" ] && [ ${CMAKE_VER_MINOR} -gt 9 ]; then
         cecho ${BAD} "Your cmake version is ${CMAKE_VER_MAJOR}.${CMAKE_VER_MINOR}, which is above 3.9."
         cecho ${INFO} "You need to switch on the cmake package in the config file!"
+        cecho ${BAD} "Please abort candi with ctrl+c to change the candi.cfg file, or"
         cecho ${GOOD} "Please confirm this by pressing enter ..."
         read
     fi

--- a/deal.II-toolchain/packages/dealii-prepare.package
+++ b/deal.II-toolchain/packages/dealii-prepare.package
@@ -26,4 +26,19 @@ if [ ! -z "${PACKAGES_OFF}" ]; then
     read
 fi
 
+# Check if we hit cmake-3.10+ and deal.II v8.5.1 configure error (MPI / FindMPI)
+# cf. https://github.com/dealii/dealii/issues/5510
+
+if [ ${DEAL_II_VERSION} = "v8.5.1" ]; then
+    # check for cmake version 3.10 and above
+    CMAKE_VER_MAJOR=$(cmake --version | perl -pe '($_)=/([0-9]+([.][0-9]+)+)/' | cut -d '.' -f1)
+    CMAKE_VER_MINOR=$(cmake --version | perl -pe '($_)=/([0-9]+([.][0-9]+)+)/' | cut -d '.' -f2)
+    if [ ${CMAKE_VER_MAJOR}=="3" ] && [ ${CMAKE_VER_MINOR} -gt 9 ]; then
+        cecho ${BAD} "Your cmake version is ${CMAKE_VER_MAJOR}.${CMAKE_VER_MINOR}, which is above 3.9."
+        cecho ${INFO} "You need to switch on the cmake package in the config file!"
+        cecho ${GOOD} "Please confirm this by pressing enter ..."
+        read
+    fi
+fi
+
 PACKAGE=dealii-prepare

--- a/deal.II-toolchain/packages/dealii.package
+++ b/deal.II-toolchain/packages/dealii.package
@@ -29,6 +29,24 @@ CONFOPTS=" \
 -D DEAL_II_WITH_ZLIB:BOOL=ON \
 ${DEAL_CONFOPTS}"
 
+
+################################################################################
+# Check if we hit cmake-3.10+ and deal.II v8.5.1 configure error (MPI / FindMPI)
+# cf. https://github.com/dealii/dealii/issues/5510
+
+if [ ${DEAL_II_VERSION} = "v8.5.1" ]; then
+    # check for cmake version 3.10 and above
+    CMAKE_VER_MAJOR=$(cmake --version | perl -pe '($_)=/([0-9]+([.][0-9]+)+)/' | cut -d '.' -f1)
+    CMAKE_VER_MINOR=$(cmake --version | perl -pe '($_)=/([0-9]+([.][0-9]+)+)/' | cut -d '.' -f2)
+    if [ ${CMAKE_VER_MAJOR}=="3" ] && [ ${CMAKE_VER_MINOR} -gt 9 ]; then
+        cecho ${BAD} "Error: deal.II v8.5.1 can not be configured with your cmake version."
+        cecho ${BAD} "Your cmake version is ${CMAKE_VER_MAJOR}.${CMAKE_VER_MINOR}, which is above 3.9."
+        cecho ${BAD} "Please switch the cmake package in candi.cfg on and run candi again!"
+        exit 1
+    fi
+fi
+
+
 ################################################################################
 # Add additional packages, if present
 


### PR DESCRIPTION
Check if cmake 3.10 (or above) used with deal.II v8.5.1 and outputs useful hints to resolve the find mpi problem.

candi recommends that the package cmake from the config file is switched on, if so everything works well again on F26 (ships currently cmake 3.10.1)