### PR TITLE
adds fedora 27 as supported platform

### DIFF
--- a/deal.II-toolchain/platforms/supported/fedora27.platform
+++ b/deal.II-toolchain/platforms/supported/fedora27.platform
@@ -1,0 +1,23 @@
+# Fedora 27
+
+# This build script assumes that you have several packages already
+# installed via Fedora's dnf using the following command:
+#
+# $ sudo dnf install \
+# @development-tools gcc-c++ cmake openmpi openmpi-devel splint \
+# patch libtool lua lua-devel \
+# blas blas-devel lapack lapack-devel \
+# doxygen graphviz graphviz-devel qt-devel \
+# metis metis-devel 
+# 
+# Please load the 'openmpi' compiler with
+# $  module load mpi/openmpi-x86_64
+# and then set the compiler enviroment variables to
+# $ export CC=mpicc; export CXX=mpicxx; export FC=mpif90; export FF=mpif77
+# before you continue!
+##
+
+#
+# Define the additional packages for this platform.
+#PACKAGES="once:cmake ${PACKAGES}"
+


### PR DESCRIPTION
the changes are tested today. even cmake 3.9 / 3.11 together with dealii v8.5.1 works as expected