### PR TITLE
add export for SCALAPACK

### DIFF
--- a/deal.II-toolchain/packages/petsc.package
+++ b/deal.II-toolchain/packages/petsc.package
@@ -98,6 +98,7 @@ package_specific_setup () {
 
 package_specific_register () {
     export PETSC_DIR=${INSTALL_PATH}
+    export SCALAPACK_DIR=${INSTALL_PATH}
 }
 
 package_specific_conf () {

--- a/deal.II-toolchain/packages/petsc.package
+++ b/deal.II-toolchain/packages/petsc.package
@@ -98,7 +98,9 @@ package_specific_setup () {
 
 package_specific_register () {
     export PETSC_DIR=${INSTALL_PATH}
-    export SCALAPACK_DIR=${INSTALL_PATH}
+    if [ ! -z "${PARMETIS_DIR}" ]; then
+        export SCALAPACK_DIR=${INSTALL_PATH}
+    fi
 }
 
 package_specific_conf () {


### PR DESCRIPTION
Turns out we already install scalapack as part of PETSc. By exporting this path, deal.II will be able to find it.