### PR TITLE
enable PETSc optimization flags

### DIFF
--- a/deal.II-toolchain/packages/petsc.package
+++ b/deal.II-toolchain/packages/petsc.package
@@ -35,6 +35,9 @@ CONFOPTS="
   --with-mpi=1
   --with-x=0
   --with-64-bit-indices=0
+  COPTFLAGS='-O3 -march=native -mtune=native'
+  CXXOPTFLAGS='-O3 -march=native -mtune=native'
+  FOPTFLAGS='-O3 -march=native -mtune=native'
 "
 
 for external_pkg in hypre; do


### PR DESCRIPTION
We are only compiling the optimized mode of PETSc, so we might as well
enable optimizations. Fixes warnings like:
```
***** WARNING: Using default C++ optimization flags -g -O
```