### PR TITLE
also export BOOST_DIR

### DIFF
--- a/deal.II-toolchain/packages/boost.package
+++ b/deal.II-toolchain/packages/boost.package
@@ -21,6 +21,7 @@ package_specific_build () {
 }
 
 package_specific_register () {
+    export BOOST_DIR=${INSTALL_PATH}
     export BOOST_ROOT=${INSTALL_PATH}
     export BOOST_INCLUDEDIR=${INSTALL_PATH}/include
     export BOOST_LIBRARYDIR=${INSTALL_PATH}/lib
@@ -32,6 +33,7 @@ package_specific_conf () {
     CONFIG_FILE=${CONFIGURATION_PATH}/${NAME}
     rm -f $CONFIG_FILE
     echo "
+export BOOST_DIR=${INSTALL_PATH}
 export BOOST_ROOT=${INSTALL_PATH}
 export BOOST_INCLUDEDIR=${INSTALL_PATH}/include
 export BOOST_LIBRARYDIR=${INSTALL_PATH}/lib


### PR DESCRIPTION
adolc and possibly other tools want BOOST_DIR instead of BOOST_ROOT, so
provide it.