### PR TITLE
Fix SLEPc package for python3

### DIFF
--- a/deal.II-toolchain/packages/slepc.package
+++ b/deal.II-toolchain/packages/slepc.package
@@ -12,6 +12,21 @@ BUILDCHAIN=custom
 
 INSTALL_PATH=${INSTALL_PATH}/${NAME}
 
+# Note that SLEPc ./configure currently does not support python3, but some
+# distros might ship with python3 as the default "python".  So select python2
+# or python2.7 if available, otherwise use python or what the user supplied in
+# PYTHON_INTERPRETER.
+if builtin command -v python2 --version > /dev/null; then
+  default PYTHON_INTERPRETER="python2"
+fi
+if builtin command -v python2.7 --version > /dev/null; then
+  default PYTHON_INTERPRETER="python2.7"
+fi
+default PYTHON_INTERPRETER="python"
+
+
+##############################################################################
+
 if [ -z "${PETSC_DIR}" ]; then
     cecho ${BAD} "slepc: error petsc variable PETSC_DIR not found."
     exit 1
@@ -24,7 +39,7 @@ package_specific_setup () {
     # make sure no other invalid SLEPC_DIR is set:
     unset SLEPC_DIR
 
-    ./configure --prefix=${INSTALL_PATH} ${CONFOPTS}
+    ${PYTHON_INTERPRETER} ./configure --prefix=${INSTALL_PATH} ${CONFOPTS}
     quit_if_fail "slepc ./configure failed"
     
     make SLEPC_DIR=$PWD PETSC_DIR=${PETSC_DIR} all install


### PR DESCRIPTION
This is the same workaround as for `PETSc`.