### PR TITLE
cmake update and tarball

### DIFF
--- a/deal.II-toolchain/packages/cmake.package
+++ b/deal.II-toolchain/packages/cmake.package
@@ -1,11 +1,47 @@
 MAJOR=3.9
 MINOR=6
 VERSION=${MAJOR}.${MINOR}
-NAME=cmake-${VERSION}
+
+# We try to determine if we have a linux platform to use tarball install
+# instead of configure/make due to possible missing autotools on some
+# HPC clusters. We need to do this, because tarball install on MacOS or
+# other platforms is not maintainable by the candi authors.
+
+if [ -z "${PLATFORM_OSTYPE}" ]; then
+    cecho ${WARN} "WARNING: could not determine your Operating System Type (assuming linux)"
+    PLATFORM_OSTYPE=linux
+fi
+
+if [ ${PLATFORM_OSTYPE} == "linux" ]; then
+    # tarball install
+    NAME=cmake-${VERSION}-Linux-x86_64
+    PACKING=.tar.gz
+    CHECKSUM=3cd4a1e13d2f42f2ff5668b13d7fd23b
+    BUILDCHAIN=ignore
+
+else
+    # configure/make/install
+    NAME=cmake-${VERSION}
+    PACKING=.tar.gz
+    CHECKSUM=084b1c8b2efc1c1ba432dea37243c0ae
+    
+    if builtin command -v cmake > /dev/null; then
+        # configure/make with cmake (older or newer version already installed)    
+        BUILDCHAIN=cmake
+	else
+        # configure/make with autotools
+        BUILDCHAIN=autotools
+    fi
+fi
+
 SOURCE=https://cmake.org/files/v${MAJOR}/
-PACKING=.tar.gz
-CHECKSUM=084b1c8b2efc1c1ba432dea37243c0ae
-BUILDCHAIN=cmake
+
+if [ ${BUILDCHAIN} == "ignore" ]; then
+    package_specific_install () {
+        cp -rf ${UNPACK_PATH}/${EXTRACTSTO} ${INSTALL_PATH}
+        INSTALL_PATH=${INSTALL_PATH}/${EXTRACTSTO}
+    }
+fi
 
 package_specific_register () {
     export PATH=${INSTALL_PATH}/bin:${PATH}

--- a/deal.II-toolchain/packages/cmake.package
+++ b/deal.II-toolchain/packages/cmake.package
@@ -1,5 +1,5 @@
-MAJOR=3.9
-MINOR=6
+MAJOR=3.11
+MINOR=2
 VERSION=${MAJOR}.${MINOR}
 
 # We try to determine if we have a linux platform to use tarball install
@@ -16,14 +16,14 @@ if [ ${PLATFORM_OSTYPE} == "linux" ]; then
     # tarball install
     NAME=cmake-${VERSION}-Linux-x86_64
     PACKING=.tar.gz
-    CHECKSUM=3cd4a1e13d2f42f2ff5668b13d7fd23b
+    CHECKSUM=55e30dd01698e9409b576008fd22394c
     BUILDCHAIN=ignore
 
 else
     # configure/make/install
     NAME=cmake-${VERSION}
     PACKING=.tar.gz
-    CHECKSUM=084b1c8b2efc1c1ba432dea37243c0ae
+    CHECKSUM=d2d554c05fc07cfae7846d2aa205f12a
     
     if builtin command -v cmake > /dev/null; then
         # configure/make with cmake (older or newer version already installed)    

--- a/deal.II-toolchain/packages/dealii-prepare.package
+++ b/deal.II-toolchain/packages/dealii-prepare.package
@@ -29,7 +29,7 @@ fi
 # Check if we hit cmake-3.10+ and deal.II v8.5.1 configure error (MPI / FindMPI)
 # cf. https://github.com/dealii/dealii/issues/5510
 
-if [ ${DEAL_II_VERSION} = "v8.5.1" ]; then
+if [ ${DEAL_II_VERSION} == "v8.5.1" ]; then
     # check for cmake version 3.10 and above
     CMAKE_VER_MAJOR=$(cmake --version | perl -pe '($_)=/([0-9]+([.][0-9]+)+)/' | cut -d '.' -f1)
     CMAKE_VER_MINOR=$(cmake --version | perl -pe '($_)=/([0-9]+([.][0-9]+)+)/' | cut -d '.' -f2)

--- a/deal.II-toolchain/packages/dealii.package
+++ b/deal.II-toolchain/packages/dealii.package
@@ -34,7 +34,7 @@ ${DEAL_CONFOPTS}"
 # Check if we hit cmake-3.10+ and deal.II v8.5.1 configure error (MPI / FindMPI)
 # cf. https://github.com/dealii/dealii/issues/5510
 
-if [ ${DEAL_II_VERSION} = "v8.5.1" ]; then
+if [ ${DEAL_II_VERSION} == "v8.5.1" ]; then
     # check for cmake version 3.10 and above
     CMAKE_VER_MAJOR=$(cmake --version | perl -pe '($_)=/([0-9]+([.][0-9]+)+)/' | cut -d '.' -f1)
     CMAKE_VER_MINOR=$(cmake --version | perl -pe '($_)=/([0-9]+([.][0-9]+)+)/' | cut -d '.' -f2)


### PR DESCRIPTION
- automatically uses tarball install or cmake/autotools depending on the platform and the availbility of cmake
- updates to v3.11.2 from 3.9.6