### PR TITLE
Enable continuous integration using Jenkins

### DIFF
--- a/.ci/dockerfile.ubuntu16
+++ b/.ci/dockerfile.ubuntu16
@@ -1,0 +1,32 @@
+FROM dealii/ubuntu16
+
+MAINTAINER timo.heister@gmail.com
+
+USER root
+
+# note: remove python after candi works with python3 by default
+
+RUN apt-get update && apt-get -yq install \
+    autoconf \
+    automake \
+    build-essential \
+    cmake \
+    gfortran \
+    git \
+    libblas-dev \
+    libblas3 \
+    liblapack-dev \
+    liblapack3 \
+    libopenmpi-dev \
+    lsb-release \
+    numdiff \
+    openmpi-bin \
+    openmpi-common \
+    python \
+    unzip \
+    wget \
+    zlib1g-dev
+
+USER dealii
+
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,7 +109,7 @@ pipeline
         lsb_release -a
         echo $WORKSPACE
         ./candi.sh -j 4 --packages="cmake"
-        source ~/deal.ii-candi/configuration/enable.sh
+        . ~/deal.ii-candi/configuration/enable.sh
         which cmake
         cmake --version
         '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,6 @@ pipeline
         dockerfile {
           dir '.ci'
           filename 'dockerfile.ubuntu16'
-          label 'has-docker'
         }
       }
       steps
@@ -66,13 +65,12 @@ pipeline
 
     stage ("default-ubuntu16")
     {
-      options {timeout(time: 240, unit: 'MINUTES')}
+      options {timeout(time: 480, unit: 'MINUTES')}
       agent
       {
         dockerfile {
           dir '.ci'
           filename 'dockerfile.ubuntu16'
-          label 'has-docker'
         }
       }
       steps
@@ -100,7 +98,6 @@ pipeline
         dockerfile {
           dir '.ci'
           filename 'dockerfile.ubuntu16'
-          label 'has-docker'
         }
       }
       steps

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline
         echo "building on node ${env.NODE_NAME}"
       }
     }
-    
+
     stage ("Check permissions")
     {
       when {
@@ -38,7 +38,7 @@ pipeline
 
     stage ("min-ubuntu16")
     {
-      options {timeout(time: 60, unit: 'MINUTES')}
+      options {timeout(time: 240, unit: 'MINUTES')}
       agent
       {
         dockerfile {
@@ -66,7 +66,7 @@ pipeline
 
     stage ("default-ubuntu16")
     {
-      options {timeout(time: 60, unit: 'MINUTES')}
+      options {timeout(time: 240, unit: 'MINUTES')}
       agent
       {
         dockerfile {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ pipeline
       }
       steps
       {
-        sh '''
+        sh '''#!/bin/bash
         lsb_release -a
         echo $WORKSPACE
         ./candi.sh -j 4 --packages="cmake"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,122 @@
+#!groovy
+
+pipeline
+{
+  agent none
+
+  parameters {
+    booleanParam(defaultValue: false, description: 'Is the pull request approved for testing?', name: 'TRUST_BUILD')
+  }
+
+  stages {
+
+    stage ("info")
+    {
+      steps
+      {
+        echo "PR: ${env.CHANGE_ID} - ${env.CHANGE_TITLE}"
+        echo "CHANGE_AUTHOR_EMAIL: ${env.CHANGE_AUTHOR_EMAIL}"
+        echo "building on node ${env.NODE_NAME}"
+      }
+    }
+    
+    stage ("Check permissions")
+    {
+      when {
+        allOf {
+            environment name: 'TRUST_BUILD', value: 'false' 
+            not {branch 'master'}
+            not {changeRequest authorEmail: "heister@clemson.edu"}
+            not {changeRequest authorEmail: "koecher@hsu-hamburg.de"}
+	    }	    
+      }
+      steps {
+          echo "Please ask an admin to rerun jenkins with TRUST_BUILD=true"
+            sh "exit 1"
+      }
+    }
+
+    stage ("min-ubuntu16")
+    {
+      options {timeout(time: 60, unit: 'MINUTES')}
+      agent
+      {
+        dockerfile {
+          dir '.ci'
+          filename 'dockerfile.ubuntu16'
+          label 'has-docker'
+        }
+      }
+      steps
+      {
+        sh '''
+        lsb_release -a
+        echo $WORKSPACE
+        ./candi.sh -j 4 --packages="dealii"
+        cp ~/deal.ii-candi/tmp/build/deal.II-*/detailed.log .
+        '''
+
+	archiveArtifacts artifacts: 'detailed.log', fingerprint: true
+
+        sh '''
+        cd ~/deal.ii-candi/tmp/build/deal.II-* && make test
+        '''
+      }
+    }
+
+    stage ("default-ubuntu16")
+    {
+      options {timeout(time: 60, unit: 'MINUTES')}
+      agent
+      {
+        dockerfile {
+          dir '.ci'
+          filename 'dockerfile.ubuntu16'
+          label 'has-docker'
+        }
+      }
+      steps
+      {
+        sh '''
+        lsb_release -a
+        echo $WORKSPACE
+        ./candi.sh -j 4
+        cp ~/deal.ii-candi/tmp/build/deal.II-*/detailed.log .
+        '''
+
+	archiveArtifacts artifacts: 'detailed.log', fingerprint: true
+
+        sh '''
+        cd ~/deal.ii-candi/tmp/build/deal.II-* && make test
+        '''
+      }
+    }
+
+    stage ("cmake-ubuntu16")
+    {
+      options {timeout(time: 60, unit: 'MINUTES')}
+      agent
+      {
+        dockerfile {
+          dir '.ci'
+          filename 'dockerfile.ubuntu16'
+          label 'has-docker'
+        }
+      }
+      steps
+      {
+        sh '''
+        lsb_release -a
+        echo $WORKSPACE
+        ./candi.sh -j 4 --packages="cmake"
+        source ~/deal.ii-candi/configuration/enable.sh
+        which cmake
+        cmake --version
+        '''
+      }
+    }
+
+  }
+
+
+}


### PR DESCRIPTION
This is an initial version to automate continuous integration testing for candi. Right now, only some example configurations using ubuntu16 are being built, but we can extend this in the future.