### PR TITLE
Bugfix parmetis macos

### DIFF
--- a/deal.II-toolchain/packages/parmetis.package
+++ b/deal.II-toolchain/packages/parmetis.package
@@ -36,10 +36,12 @@ package_specific_build() {
 }
 
 package_specific_patch () {
-    if [ ${PLATFORM_OSTYPE} == linux && ${VERSION} == "4.0.3" ]; then
-        cd ${UNPACK_PATH}/${EXTRACTSTO}
-        cecho ${WARN} "applying patch for building METIS shared libraries"
-        patch -p0 --forward < ${ORIG_DIR}/${PROJECT}/patches/parmetis-4.0.3-build.patch || true
+    if [ ${PLATFORM_OSTYPE} == linux ]; then
+        if [ ${VERSION} == "4.0.3" ]; then
+            cd ${UNPACK_PATH}/${EXTRACTSTO}
+            cecho ${WARN} "applying patch for building METIS shared libraries"
+            patch -p0 --forward < ${ORIG_DIR}/${PROJECT}/patches/parmetis-4.0.3-build.patch || true
+        fi
     fi
 }
 

--- a/deal.II-toolchain/packages/parmetis.package
+++ b/deal.II-toolchain/packages/parmetis.package
@@ -36,7 +36,7 @@ package_specific_build() {
 }
 
 package_specific_patch () {
-    if [ ${VERSION} == "4.0.3" ]; then
+    if [ ${PLATFORM_OSTYPE} == linux && ${VERSION} == "4.0.3" ]; then
         cd ${UNPACK_PATH}/${EXTRACTSTO}
         cecho ${WARN} "applying patch for building METIS shared libraries"
         patch -p0 --forward < ${ORIG_DIR}/${PROJECT}/patches/parmetis-4.0.3-build.patch || true
@@ -66,3 +66,4 @@ export PARMETIS_DIR=${INSTALL_PATH}
 " >> $CONFIG_FILE
     fi
 }
+

--- a/deal.II-toolchain/packages/parmetis.package
+++ b/deal.II-toolchain/packages/parmetis.package
@@ -36,10 +36,10 @@ package_specific_build() {
 }
 
 package_specific_patch () {
-    if [ "$VERSION" = "4.0.3" ]; then
-      cd ${UNPACK_PATH}/${EXTRACTSTO}
-      cecho ${WARN} "applying patch for building METIS shared libraries"
-      patch -p0 --forward < ${ORIG_DIR}/${PROJECT}/patches/parmetis-4.0.3-build.patch || true
+    if [ ${VERSION} == "4.0.3" ]; then
+        cd ${UNPACK_PATH}/${EXTRACTSTO}
+        cecho ${WARN} "applying patch for building METIS shared libraries"
+        patch -p0 --forward < ${ORIG_DIR}/${PROJECT}/patches/parmetis-4.0.3-build.patch || true
     fi
 }
 


### PR DESCRIPTION
Since commit b6e293838e286b44e2031e5734d6579dd4220fbe it seems that the MacOS build for at least superlu_dist and trilinos is broken. This PR resolves that in a way, that only on linux type OS platforms the patch for parmetis 4.0.3 will be applied. I'm still working on a solution for mac os including the patch, but this will be done in a future PR.