### PR TITLE
centos 7: bug: force to have parmetis 4.0.3 installed

### DIFF
--- a/deal.II-toolchain/packages/trilinos.package
+++ b/deal.II-toolchain/packages/trilinos.package
@@ -111,6 +111,7 @@ if [ ! -z "${PARMETIS_DIR}" ]; then
     	
     CONFOPTS="\
         ${CONFOPTS} \
+        ${TRILINOS_PARMETIS_CONFOPTS} \
         -D TPL_ENABLE_ParMETIS:BOOL=ON \
         -D TPL_ParMETIS_LIBRARIES:FILEPATH=${PARMETIS_DIR}/lib/libparmetis.${LDSUFFIX} \
         -D TPL_ParMETIS_INCLUDE_DIRS:PATH=${PARMETIS_DIR}/include"

--- a/deal.II-toolchain/platforms/supported/centos7.platform
+++ b/deal.II-toolchain/platforms/supported/centos7.platform
@@ -19,6 +19,12 @@
 # before you continue!
 ##
 
+# on centos 7 the candi installed parmetis 4.0.3 is not recognized correctly
+# for trilinos 12-10-1. We force to assume parmetis version 4.0.3.
+TRILINOS_PARMETIS_CONFOPTS="\
+    ${TRILINOS_PARMETIS_CONFOPTS} \
+    -D HAVE_PARMETIS_VERSION_4_0_3=ON"
+
 #
 # Define the additional packages for this platform.
 #PACKAGES="once:cmake ${PACKAGES}"

--- a/deal.II-toolchain/platforms/supported/rhel7.platform
+++ b/deal.II-toolchain/platforms/supported/rhel7.platform
@@ -18,6 +18,12 @@
 # before you continue!
 ##
 
+# on rhel 7 the candi installed parmetis 4.0.3 is not recognized correctly
+# for trilinos 12-10-1. We force to assume parmetis version 4.0.3.
+TRILINOS_PARMETIS_CONFOPTS="\
+    ${TRILINOS_PARMETIS_CONFOPTS} \
+    -D HAVE_PARMETIS_VERSION_4_0_3=ON"
+
 #
 # Define the additional packages for this platform.
 #PACKAGES="once:cmake ${PACKAGES}"


### PR DESCRIPTION
This PR resolves the current issue on centos 7 that parmetis is not detected in its correct version.
I've run a test on a centos 7 machine, now the default configuration compiles correctly and step-32 and step-42 (trilinos step tutorials) runs fine.