### PR TITLE
p4est: corrects zlib detection for user-installed zlib

### DIFF
--- a/deal.II-toolchain/packages/p4est.package
+++ b/deal.II-toolchain/packages/p4est.package
@@ -16,8 +16,15 @@ package_specific_setup () {
 
     # export zlib if we installed it ourselves
     if [ ! -z "${ZLIB_DIR}" ]; then
-      LIBS="-L${ZLIB_LIBPATH}"
-      CFLAGS="$CFLAGS -I${ZLIB_INCLUDE}"
+        if [ -z "${ZLIB_LIBPATH}" ]; then
+            ZLIB_LIBPATH=${ZLIB_DIR}/lib
+        fi
+        LIBS="-L${ZLIB_LIBPATH}"
+
+        if [ -z "${ZLIB_INCLUDE}" ]; then
+            ZLIB_INCLUDE=${ZLIB_DIR}/include
+        fi
+        CFLAGS="$CFLAGS -I${ZLIB_INCLUDE}"
     fi
 
     if test -z "$CFLAGS" -a -z "$P4EST_CFLAGS_FAST" ; then

--- a/deal.II-toolchain/packages/zlib.package
+++ b/deal.II-toolchain/packages/zlib.package
@@ -17,7 +17,7 @@ package_specific_build () {
 }
 
 package_specific_register () {
-    export ZLIB_DIR=${INSTALL_PATH}/
+    export ZLIB_DIR=${INSTALL_PATH}
     export ZLIB_INCLUDE=${INSTALL_PATH}/include
     export ZLIB_LIBPATH=${INSTALL_PATH}/lib
 }
@@ -27,7 +27,7 @@ package_specific_conf () {
     CONFIG_FILE=${CONFIGURATION_PATH}/${NAME}
     rm -f $CONFIG_FILE
     echo "
-export ZLIB_DIR=${INSTALL_PATH}/
+export ZLIB_DIR=${INSTALL_PATH}
 export ZLIB_INCLUDE=${INSTALL_PATH}/include
 export ZLIB_LIBPATH=${INSTALL_PATH}/lib
 " >> $CONFIG_FILE


### PR DESCRIPTION
If only `ZLIB_DIR` is set, an p4est MPI C error might occur, since zlib is not correctly embedded to the p4est configuration. This PR resolves this issue.

Note that this can currently not happen for the zlib.package provided by candi - but anyhow - for different installations this is a problem.