### PR TITLE
Update apt-get instructions for debian9.platform

### DIFF
--- a/deal.II-toolchain/platforms/supported/debian9.platform
+++ b/deal.II-toolchain/platforms/supported/debian9.platform
@@ -1,11 +1,11 @@
 # debian 9
 #
 # This build script assumes that you have several packages already
-# installed via ubuntu's apt-get using the following commands:
+# installed via debian's apt-get using the following commands:
 #
 # > sudo apt-get install build-essential automake autoconf gfortran \
 #   openmpi-bin openmpi-common libopenmpi-dev cmake subversion git \
-#   libblas-dev liblapack-dev libblas3gf liblapack3gf splint tcl tcl-dev \
+#   libblas-dev liblapack-dev libblas3 liblapack3 splint tcl tcl-dev \
 #   environment-modules libsuitesparse-dev libtool libboost-all-dev \
 #   qt4-dev-tools
 #


### PR DESCRIPTION
On Debian 9, `libblas3gf` and `liblapack3gf` are replaced by `libblas3` and `liblapack3`, respectively. These were previous [transitional](https://packages.debian.org/jessie/libblas3gf) [packages](https://packages.debian.org/jessie/liblapack3gf) in the previous Debian 8 release.

Also replace "ubuntu's" with "debian's" in the description.