### PR TITLE
switch deal.II v9.0.0 -> v9.0.1

### DIFF
--- a/candi.cfg
+++ b/candi.cfg
@@ -62,7 +62,7 @@ PACKAGES="${PACKAGES} dealii"
 #########################################################################
 
 # Install the following deal.II version:
-DEAL_II_VERSION=v9.0.0
+DEAL_II_VERSION=v9.0.1
 
 # Would you like to build stable version of deal.II?
 # If STABLE_BUILD=false, then the development version of deal.II will be


### PR DESCRIPTION
simple test run on fedora 28 with default compiler works fine. I think this should be safe to merge.