### PR TITLE
git cherry-pick enhancement

### DIFF
--- a/candi.cfg
+++ b/candi.cfg
@@ -94,7 +94,7 @@ MKL=OFF
 # If you have commits from the deal.II master to cherry-pick in STABLE_BUILD
 
 # bugfix for TrilinosWrapper::SparseMatrix ::add(factor, SparseMatrix)
-DEAL_CHERRYPICKCOMMITS="8bcaf55df6754238b2e4e41bf6a5dd276a97bdd2"
+#DEAL_CHERRYPICKCOMMITS="8bcaf55df6754238b2e4e41bf6a5dd276a97bdd2 ${DEAL_CHERRYPICKCOMMITS}"
 
 #########################################################################
 

--- a/candi.cfg
+++ b/candi.cfg
@@ -91,8 +91,16 @@ MKL=OFF
 
 #########################################################################
 
+# If you have commits from the deal.II master to cherry-pick in STABLE_BUILD
+
+# bugfix for TrilinosWrapper::SparseMatrix ::add(factor, SparseMatrix)
+DEAL_CHERRYPICKCOMMITS="8bcaf55df6754238b2e4e41bf6a5dd276a97bdd2"
+
+#########################################################################
+
 # If you want to change the source code of one or multiple packages
 # switch on the developer mode to avoid a package fetch and unpack.
 # Note: a previous run of candi with the same settings must be done without
 #       this mode!
 DEVELOPER_MODE=OFF
+

--- a/candi.sh
+++ b/candi.sh
@@ -350,6 +350,14 @@ package_fetch () {
             git checkout ${VERSION} --force
             quit_if_fail "candi: git checkout ${VERSION} --force failed"
         fi
+        
+        # git cherry-pick on commits given by ${CHERRYPICKCOMMITS}
+        if [ ${STABLE_BUILD} = true ] && [ ! -z "${CHERRYPICKCOMMITS}" ]; then
+            cecho ${INFO} "candi: git cherry-pick -X theirs ${CHERRYPICKCOMMITS}"
+            cd ${EXTRACTSTO}
+            git cherry-pick -X theirs ${CHERRYPICKCOMMITS}
+            quit_if_fail "candi: git cherry-pick -X theirs ${CHERRYPICKCOMMITS} failed"
+        fi
 
     elif [ ${PACKING} = "hg" ]; then
         cd ${UNPACK_PATH}
@@ -1049,6 +1057,7 @@ for PACKAGE in ${PACKAGES[@]}; do
     unset CONFOPTS
     unset MAKEOPTS
     unset CONFIG_FILE
+    unset CHERRYPICKCOMMITS
     TARGETS=('' install)
     PROCS=${ORIG_PROCS}
     INSTALL_PATH=${ORIG_INSTALL_PATH}

--- a/candi.sh
+++ b/candi.sh
@@ -349,6 +349,7 @@ package_fetch () {
             cd ${EXTRACTSTO}
             git checkout ${VERSION} --force
             quit_if_fail "candi: git checkout ${VERSION} --force failed"
+            cd ..
         fi
         
         # git cherry-pick on commits given by ${CHERRYPICKCOMMITS}
@@ -357,6 +358,7 @@ package_fetch () {
             cd ${EXTRACTSTO}
             git cherry-pick -X theirs ${CHERRYPICKCOMMITS}
             quit_if_fail "candi: git cherry-pick -X theirs ${CHERRYPICKCOMMITS} failed"
+            cd ..
         fi
 
     elif [ ${PACKING} = "hg" ]; then

--- a/candi.sh
+++ b/candi.sh
@@ -351,15 +351,6 @@ package_fetch () {
             quit_if_fail "candi: git checkout ${VERSION} --force failed"
             cd ..
         fi
-        
-        # git cherry-pick on commits given by ${CHERRYPICKCOMMITS}
-        if [ ${STABLE_BUILD} = true ] && [ ! -z "${CHERRYPICKCOMMITS}" ]; then
-            cecho ${INFO} "candi: git cherry-pick -X theirs ${CHERRYPICKCOMMITS}"
-            cd ${EXTRACTSTO}
-            git cherry-pick -X theirs ${CHERRYPICKCOMMITS}
-            quit_if_fail "candi: git cherry-pick -X theirs ${CHERRYPICKCOMMITS} failed"
-            cd ..
-        fi
 
     elif [ ${PACKING} = "hg" ]; then
         cd ${UNPACK_PATH}
@@ -429,6 +420,14 @@ package_unpack() {
         elif [ ${PACKING} = ".zip" ]; then
             unzip ${FILE_TO_UNPACK}
         fi
+    fi
+
+    # Apply patches with git cherry-pick of commits given by ${CHERRYPICKCOMMITS}
+    if [ ${PACKING} = "git" ] && [ ! -z "${CHERRYPICKCOMMITS}" ]; then
+        cecho ${INFO} "candi: git cherry-pick -X theirs ${CHERRYPICKCOMMITS}"
+        cd ${UNPACK_PATH}/${EXTRACTSTO}
+        git cherry-pick -X theirs ${CHERRYPICKCOMMITS}
+        quit_if_fail "candi: git cherry-pick -X theirs ${CHERRYPICKCOMMITS} failed"
     fi
 
     # Apply patches

--- a/deal.II-toolchain/packages/dealii.package
+++ b/deal.II-toolchain/packages/dealii.package
@@ -46,6 +46,14 @@ if [ ${DEAL_II_VERSION} == "v8.5.1" ]; then
     fi
 fi
 
+################################################################################
+# Check if we have commits to be cherry-picked by git
+
+if [ ! -z "${DEAL_CHERRYPICKCOMMITS}" ]; then
+    CHERRYPICKCOMMITS=" \
+        ${DEAL_CHERRYPICKCOMMITS}"
+    cecho ${INFO} "deal.II: git cherry-pick -X theirs ${CHERRYPICKCOMMITS}"
+fi
 
 ################################################################################
 # Add additional packages, if present


### PR DESCRIPTION
This PR is an enhancement to candi to allow for cherry-picks of development commits to a stable release.

The reason is, that a more or less long time undergoes between two stable releases within a package and sometimes there is the need (for a candi-user or from our developer side) to select a very little number of (development) commits added to a stable release without using the complete unstable development version.

This PR includes an example for a bugfix of a deal.II class (disabled by default), but it can be used for other packages which we check out with git.

For future use, maybe problems as in PR #92 can be easily resolved with that within candi.

I barely checked that this PR does not break anything in candi, i.e. initial build experience for deal.II v9.0.0 for fedora 28. Further tests might be required.