### PR TITLE
opensuse fixes

### DIFF
--- a/deal.II-toolchain/platforms/supported/opensuse15.platform
+++ b/deal.II-toolchain/platforms/supported/opensuse15.platform
@@ -7,7 +7,7 @@
 #
 # > su -c 'zypper -n install \
 #          python gcc gcc-c++ gcc-fortran subversion git cmake \
-#          openmpi3 openmpi3-devel blas-devel lapack-devel'
+#          binutils-gold mpich-devel blas-devel lapack-devel'
 #
 # optional packages:
 # Modules doxygen graphviz graphviz-devel devel_qt4 splint


### PR DESCRIPTION
- switch to mpich (fewer runtime warnings)
- install ld gold (avoids slow linking)