### PR TITLE
fix path directive in cmake package

### DIFF
--- a/deal.II-toolchain/packages/cmake.package
+++ b/deal.II-toolchain/packages/cmake.package
@@ -52,7 +52,7 @@ package_specific_conf () {
     CONFIG_FILE=${CONFIGURATION_PATH}/${NAME}
     rm -f $CONFIG_FILE
     echo "
-export PATH=${INSTALL_PATH}/bin:${PATH}
+export PATH=${INSTALL_PATH}/bin:\${PATH}
 export CMAKE_ROOT=${INSTALL_PATH}/share/${MAJOR}
 " >> $CONFIG_FILE
 }


### PR DESCRIPTION
otherwise $PATH will be expanded in the config file. We do this in all other packages already.