### PR TITLE
take over #111 to dealii-9.0

### DIFF
--- a/candi.cfg
+++ b/candi.cfg
@@ -28,6 +28,9 @@ MIRROR="https://tjhei.info/candi-mirror/ https://cecas.clemson.edu/dealii/mirror
 #Choose configuration and components of deal.II
 DEAL_CONFOPTS=""
 
+# enable machine-specific optimizations (implies -march=native etc.)?
+#NATIVE_OPTIMIZATIONS=true
+
 PACKAGES="load:dealii-prepare"
 
 # These are system dependencies that are often pre-installed:

--- a/deal.II-toolchain/packages/dealii.package
+++ b/deal.II-toolchain/packages/dealii.package
@@ -26,7 +26,16 @@ CONFOPTS=" \
 -D DEAL_II_FORCE_BUNDLED_UMFPACK:BOOL=OFF \
 -D DEAL_II_WITH_BOOST:BOOL=ON \
 -D DEAL_II_FORCE_BUNDLED_BOOST:BOOL=OFF \
--D DEAL_II_WITH_ZLIB:BOOL=ON \
+-D DEAL_II_WITH_ZLIB:BOOL=ON"
+
+if [ "${NATIVE_OPTIMIZATIONS}" = "true" ]; then
+    CONFOPTS="${CONFOPTS} \
+      -D CMAKE_CXX_FLAGS='-march=native'
+    "
+fi
+
+# add the user-specified flags at the end (so things can be overriden):
+CONFOPTS="${CONFOPTS} \
 ${DEAL_CONFOPTS}"
 
 

--- a/deal.II-toolchain/packages/dealii.package
+++ b/deal.II-toolchain/packages/dealii.package
@@ -30,8 +30,7 @@ CONFOPTS=" \
 
 if [ "${NATIVE_OPTIMIZATIONS}" = "true" ]; then
     CONFOPTS="${CONFOPTS} \
-      -D CMAKE_CXX_FLAGS='-march=native'
-    "
+      -D CMAKE_CXX_FLAGS='-march=native'"
 fi
 
 # add the user-specified flags at the end (so things can be overriden):

--- a/deal.II-toolchain/packages/petsc.package
+++ b/deal.II-toolchain/packages/petsc.package
@@ -38,11 +38,10 @@ CONFOPTS="
 "
 
 if [ "${NATIVE_OPTIMIZATIONS}" = "true" ]; then
-    CONFOPTS="${CONFOPTS}
-      COPTFLAGS='-O3 -march=native -mtune=native'
-      CXXOPTFLAGS='-O3 -march=native -mtune=native'
-      FOPTFLAGS='-O3 -march=native -mtune=native'
-    "
+    CONFOPTS="${CONFOPTS} \
+      COPTFLAGS='-O3 -march=native -mtune=native' \
+      CXXOPTFLAGS='-O3 -march=native -mtune=native' \
+      FOPTFLAGS='-O3 -march=native -mtune=native'"
 fi
 
 

--- a/deal.II-toolchain/packages/petsc.package
+++ b/deal.II-toolchain/packages/petsc.package
@@ -37,6 +37,15 @@ CONFOPTS="
   --with-64-bit-indices=0
 "
 
+if [ "${NATIVE_OPTIMIZATIONS}" = "true" ]; then
+    CONFOPTS="${CONFOPTS}
+      COPTFLAGS='-O3 -march=native -mtune=native'
+      CXXOPTFLAGS='-O3 -march=native -mtune=native'
+      FOPTFLAGS='-O3 -march=native -mtune=native'
+    "
+fi
+
+
 for external_pkg in hypre; do
     CONFOPTS="${CONFOPTS} --download-${external_pkg}=1"
 done


### PR DESCRIPTION
Introduce a new settings to allow native optimizations. This currently
affects PETSc and deal.II (basically setting march=native).