### PR TITLE
update hdf5 to 1.10.5

### DIFF
--- a/deal.II-toolchain/packages/hdf5.package
+++ b/deal.II-toolchain/packages/hdf5.package
@@ -1,10 +1,10 @@
 MAJORVER=1.10
-MINORVER=1
+MINORVER=5
 VERSION=${MAJORVER}.${MINORVER}
 NAME=hdf5-${VERSION}
 SOURCE=http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-${MAJORVER}/${NAME}/src/
 PACKING=.tar.gz
-CHECKSUM=43a2f9466702fb1db31df98ae6677f15
+CHECKSUM=e115eeb66e944fa7814482415dd21cc4
 BUILDCHAIN=autotools
 
 CONFOPTS="--enable-shared --enable-parallel"


### PR DESCRIPTION
Required to link with a newer version of MPI:
```
/home/heister/shared-
dealii/dealii-v9.1.1/tmp/unpack/hdf5-1.10.1/testpar/t_cache.c:1222:27:
error: call to ‘MPI_Address’ declared with attribute error: MPI_Address
was removed in MPI-3.0.  Use MPI_Get_address instead.
```

This should go into 9.1 as well.