### PR TITLE
allow checksum alternatives to fix trilinos download

### DIFF
--- a/candi.sh
+++ b/candi.sh
@@ -222,30 +222,25 @@ verify_archive() {
 
     # Verify CHECKSUM using md5/md5sum
     if builtin command -v md5 > /dev/null; then
-        test "${CHECKSUM}" = "$(md5 -q ${ARCHIVE_FILE})"
-        if [ $? = 0 ]; then
-            echo "${ARCHIVE_FILE}: OK"
-            return 0
-        else
-            echo "${ARCHIVE_FILE}: FAILED"
-            return 3
-        fi
-
+	CURRENT="$(md5 -q ${ARCHIVE_FILE})"
     elif builtin command -v md5sum > /dev/null; then
-        echo "${CHECKSUM}  ${ARCHIVE_FILE}" | md5sum --check -
-        if [ $? = 0 ]; then
-            return 0
-        else
-            return 3
-        fi
-
+	CURRENT=$(md5sum ${ARCHIVE_FILE} | awk '{print $1}')
     else
         cecho ${BAD} "Neither md5 nor md5sum were found in the PATH"
         return 4
     fi
 
-    # Internal error: we should never reach this point, but to be sure we
-    return -1
+    for CHECK in ${CHECKSUM}; do
+        test "${CHECK}" = "${CURRENT}"
+        if [ $? = 0 ]; then
+            echo "${ARCHIVE_FILE}: OK"
+            return 0
+	fi
+    done
+
+    cecho ${BAD} "${ARCHIVE_FILE}: FAILED"
+    cecho ${BAD} "${CURRENT} does not match any in ${CHECKSUM}"
+    return 3
 }
 
 download_archive () {

--- a/deal.II-toolchain/packages/trilinos.package
+++ b/deal.II-toolchain/packages/trilinos.package
@@ -3,8 +3,11 @@ if [ -z "${TRILINOS_MAJOR_VERSION}" ]; then
 fi
 
 if [ ${TRILINOS_MAJOR_VERSION} = "AUTO" ] || [ ${TRILINOS_MAJOR_VERSION} = "12" ]; then
+
+    # note: the official trilinos tarball changed md5sum but we confirmed that the contents is
+    # identical. We accept both hashes here.
     VERSION=12-10-1
-    CHECKSUM=40f28628b63310f9bd17c26d9ebe32b1
+    CHECKSUM="667333dbd7c0f031d47d7c5511fd0810 40f28628b63310f9bd17c26d9ebe32b1"
     
     #VERSION=12-4-2
     #CHECKSUM=4c25a757d86bde3531090bd900a2cea8


### PR DESCRIPTION
- allow alternative checksums to be specified
- add a second checksum for trilinos as the original file changed