### PR TITLE
bc and python must be available on ubuntu

### DIFF
--- a/deal.II-toolchain/platforms/supported/ubuntu16.platform
+++ b/deal.II-toolchain/platforms/supported/ubuntu16.platform
@@ -4,7 +4,7 @@
 # installed via ubuntu's apt-get using the following commands:
 #
 # > sudo apt-get install build-essential lsb-release wget \
-#   automake autoconf gfortran \
+#   bc python automake autoconf gfortran \
 #   openmpi-bin openmpi-common libopenmpi-dev cmake subversion git \
 #   libblas-dev liblapack-dev libblas3 liblapack3 \
 #   libsuitesparse-dev libtool libboost-all-dev zlib1g-dev \

--- a/deal.II-toolchain/platforms/supported/ubuntu18.platform
+++ b/deal.II-toolchain/platforms/supported/ubuntu18.platform
@@ -4,7 +4,7 @@
 # installed via ubuntu's apt-get using the following commands:
 #
 # > sudo apt-get install build-essential lsb-release wget \
-#   automake autoconf gfortran \
+#   bc python automake autoconf gfortran \
 #   openmpi-bin openmpi-common libopenmpi-dev cmake subversion git \
 #   libblas-dev liblapack-dev libblas3 liblapack3 \
 #   libsuitesparse-dev libtool libboost-all-dev zlib1g-dev \

--- a/deal.II-toolchain/platforms/supported/ubuntu19.platform
+++ b/deal.II-toolchain/platforms/supported/ubuntu19.platform
@@ -4,7 +4,7 @@
 # installed via ubuntu's apt-get using the following commands:
 #
 # > sudo apt-get install build-essential lsb-release wget \
-#   automake autoconf gfortran \
+#   bc python automake autoconf gfortran \
 #   openmpi-bin openmpi-common libopenmpi-dev cmake subversion git \
 #   libblas-dev liblapack-dev libblas3 liblapack3 \
 #   libsuitesparse-dev libtool libboost-all-dev zlib1g-dev

--- a/deal.II-toolchain/platforms/supported/ubuntu20.platform
+++ b/deal.II-toolchain/platforms/supported/ubuntu20.platform
@@ -4,7 +4,7 @@
 # installed via ubuntu's apt-get using the following commands:
 #
 # > sudo apt-get install build-essential lsb-release wget \
-#   automake autoconf gfortran \
+#   bc python automake autoconf gfortran \
 #   openmpi-bin openmpi-common libopenmpi-dev cmake subversion git \
 #   libblas-dev liblapack-dev libblas3 liblapack3 \
 #   libsuitesparse-dev libtool libboost-all-dev zlib1g-dev


### PR DESCRIPTION
Docker images for various ubuntu version are very lightweight and don't provide some basic packages. I was installing candi in a docker environment and realized the script needs `python` and Trilinos installation needs the `bc` command. These packages are available on almost all desktop installations of ubuntu, but I think we should remind the user to install them on docker images.

