### PR TITLE
handle python3 correctly

### DIFF
--- a/candi.cfg
+++ b/candi.cfg
@@ -31,6 +31,12 @@ DEAL_CONFOPTS=""
 # enable machine-specific optimizations (implies -march=native etc.)?
 #NATIVE_OPTIMIZATIONS=true
 
+# Choose the python interpreter to use. We pick python2, python3,
+# python in that order by default. If you want to override this
+# choice, uncomment the following:
+#PYTHON_INTERPRETER=python3
+
+# Now we pick the packages to install:
 PACKAGES="load:dealii-prepare"
 
 # These are system dependencies that are often pre-installed:

--- a/candi.sh
+++ b/candi.sh
@@ -497,7 +497,7 @@ package_build() {
 
     elif [ ${BUILDCHAIN} = "python" ]; then
         echo cp -rf ${UNPACK_PATH}/${EXTRACTSTO}/* . >>candi_configure
-        echo python setup.py install --prefix=${INSTALL_PATH} >>candi_build
+        echo ${PYTHON_INTERPRETER} setup.py install --prefix=${INSTALL_PATH} >>candi_build
 
     elif [ ${BUILDCHAIN} = "scons" ]; then
         echo cp -rf ${UNPACK_PATH}/${EXTRACTSTO}/* . >>candi_configure
@@ -975,9 +975,22 @@ cecho ${GOOD} "Project:  ${PROJECT}"
 cecho ${GOOD} "Platform: ${PLATFORM}"
 echo
 
-# If the platform doesn't override the system python by installing its
-# own, figure out the version of the existing python
-default PYTHONVER=`python -c "import sys; print(sys.version[:3])"`
+
+# Figure out what binary to use for python support. Note that older PETSc ./configure only supports python2. For now, prefer
+# using python2 but use what the user supplies as PYTHON_INTERPRETER.
+if builtin command -v python2 --version > /dev/null; then
+  default PYTHON_INTERPRETER="python2"
+fi
+if builtin command -v python2.7 --version > /dev/null; then
+  default PYTHON_INTERPRETER="python2.7"
+fi
+if builtin command -v python3 --version > /dev/null; then
+  default PYTHON_INTERPRETER="python3"
+fi
+default PYTHON_INTERPRETER="python"
+
+# Figure out the version of the existing python:
+default PYTHONVER=`${PYTHON_INTERPRETER} -c "import sys; print(sys.version[:3])"`
 
 # Create necessary directories and set appropriate variables
 mkdir -p ${DOWNLOAD_PATH}

--- a/deal.II-toolchain/packages/petsc.package
+++ b/deal.II-toolchain/packages/petsc.package
@@ -19,19 +19,6 @@ BUILDCHAIN=custom
 
 INSTALL_PATH=${INSTALL_PATH}/${EXTRACTSTO}
 
-# Note that older PETSc ./configure only supports python2. For now, prefer
-# using python2 but use what the user supplies as PYTHON_INTERPRETER.
-if builtin command -v python2 --version > /dev/null; then
-  default PYTHON_INTERPRETER="python2"
-fi
-if builtin command -v python2.7 --version > /dev/null; then
-  default PYTHON_INTERPRETER="python2.7"
-fi
-if builtin command -v python3 --version > /dev/null; then
-  default PYTHON_INTERPRETER="python3"
-fi
-default PYTHON_INTERPRETER="python"
-
 
 #########################################################################
 

--- a/deal.II-toolchain/packages/slepc.package
+++ b/deal.II-toolchain/packages/slepc.package
@@ -18,19 +18,6 @@ BUILDCHAIN=custom
 
 INSTALL_PATH=${INSTALL_PATH}/${NAME}
 
-# Note that older SLEPc ./configure only supports python2. For now, prefer
-# using python2 but use what the user supplies as PYTHON_INTERPRETER.
-if builtin command -v python2 --version > /dev/null; then
-  default PYTHON_INTERPRETER="python2"
-fi
-if builtin command -v python2.7 --version > /dev/null; then
-  default PYTHON_INTERPRETER="python2.7"
-fi
-if builtin command -v python3 --version > /dev/null; then
-  default PYTHON_INTERPRETER="python3"
-fi
-default PYTHON_INTERPRETER="python"
-
 
 ##############################################################################
 


### PR DESCRIPTION
If "python" does not exist in the environment, we set PYTHONVER to the
empty string, which makes configuration fail. Fix this.