### PR TITLE
CI: fix OSX tester

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,13 +28,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: setup
+      run: |
+        # force cmake version:
+        pip install cmake==3.18.4
+        echo "/Library/Frameworks/Python.framework/Versions/2.7/bin" >> $GITHUB_PATH
+        brew install openmpi
     - name: info
       run: |
-        g++ -v
+        mpicxx -v
         cmake --version
     - name: build
       run: |
-        echo 'DEAL_CONFOPTS="-D DEAL_II_WITH_MPI=OFF"' >> candi.cfg
         ./candi.sh -j 2 --packages="dealii"
         cd ~/deal.ii-candi/tmp/build/deal.II-* && make test
 
@@ -46,6 +51,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: setup
       run: |
+        # force cmake version:
+        pip install cmake==3.18.4
+        echo "/Library/Frameworks/Python.framework/Versions/2.7/bin" >> $GITHUB_PATH
         brew install openmpi
     - name: info
       run: |


### PR DESCRIPTION
- force cmake 3.18 as 9.2 does not support 3.19 (default in the VM)
- change the minimal build to use MPI as well (without it, blas is not
found for some reason). There is no good reason to test candi builds
without MPI.