### PR TITLE
Addresses issue #154 CentOS cmake is too old

### DIFF
--- a/deal.II-toolchain/platforms/supported/centos7.platform
+++ b/deal.II-toolchain/platforms/supported/centos7.platform
@@ -21,5 +21,5 @@
 
 #
 # Define the additional packages for this platform.
-#PACKAGES="once:cmake ${PACKAGES}"
+PACKAGES="once:cmake ${PACKAGES}"
 


### PR DESCRIPTION
By default the cmake package from centos is too old to build Trilionos (and possibly dealii as well):
```
$ cmake --version
cmake version 2.8.12.2
```
There is a cmake3 package, but it installs as cmake3, an alternative to this PR might be to install `cmake3` as a prerequisite and somehow tell the build process to use `cmake3` instead of `cmake`
```
$ cmake3 --version
cmake3 version 3.17.3
```

This change tells candii to fetch and build cmake from source instead of worrying about what version the system has.