### PR TITLE
Add option to skip prompts

### DIFF
--- a/candi.sh
+++ b/candi.sh
@@ -42,6 +42,7 @@ TIC_GLOBAL="$(${DATE_CMD} +%s)"
 PREFIX=~/deal.ii-candi
 PROCS=1
 CMD_PACKAGES=""
+SKIP_READ=false
 
 while [ -n "$1" ]; do
     param="$1"
@@ -56,6 +57,7 @@ while [ -n "$1" ]; do
 	    echo "  -j <N>, -j<N>, --PROCS=<N>  compile with N processes in parallel (default $PROCS)"
 	    echo "  --platform=<platform>       force usage of a particular platform file"
 	    echo "  --packages=\"pkg1 pkg2\"      install the given list of packages instead of the default set in candi.cfg"
+	    echo "  -y, --yes                   assume yes to prompts"
 	    echo ""
 	    echo "The configuration including the choice of packages to install is stored in candi.cfg, see README.md for more information."
 	    exit 0
@@ -100,6 +102,12 @@ while [ -n "$1" ]; do
         -pf=*|--platform=*)
             GIVEN_PLATFORM="${param#*=}"
         ;;
+
+	#####################################
+	# Assume yes
+	-y|--yes)
+	    SKIP_READ=true
+	;;
 
 	*)
 	    echo "invalid command line option. See -h for more information."
@@ -163,9 +171,11 @@ cecho() {
 }
 
 cls() {
-    # clear screen
-    COL=$1; shift
-    echo -e "${COL}$@\033c"
+    if [ ${SKIP_READ} = false ]; then
+        # clear screen
+        COL=$1; shift
+        echo -e "${COL}$@\033c"
+    fi
 }
 
 default () {
@@ -817,14 +827,16 @@ echo
 
 # Let the user confirm now, that the PLATFORM is set up correctly
 echo "-------------------------------------------------------------------------------"
-cecho ${GOOD} "Please make sure you've read the instructions above and your system"
-cecho ${GOOD} "is ready for installing ${PROJECT}."
-cecho ${BAD} "If not, please abort the installer by pressing <CTRL> + <C> !"
-cecho ${INFO} "Then copy and paste these instructions into this terminal."
-echo
+if [ ${SKIP_READ} = false ]; then
+    cecho ${GOOD} "Please make sure you've read the instructions above and your system"
+    cecho ${GOOD} "is ready for installing ${PROJECT}."
+    cecho ${BAD} "If not, please abort the installer by pressing <CTRL> + <C> !"
+    cecho ${INFO} "Then copy and paste these instructions into this terminal."
+    echo
 
-cecho ${GOOD} "Once ready, hit enter to continue!"
-read
+    cecho ${GOOD} "Once ready, hit enter to continue!"
+    read
+fi
 
 ################################################################################
 # Output configuration details
@@ -963,8 +975,10 @@ fi
 ################################################################################
 # Force the user to accept the current output
 echo "-------------------------------------------------------------------------------"
-cecho ${GOOD} "Once ready, hit enter to continue!"
-read
+if [ ${SKIP_READ} = false ]; then
+    cecho ${GOOD} "Once ready, hit enter to continue!"
+    read
+fi
 
 ################################################################################
 # Output configuration details


### PR DESCRIPTION
When we want to submit the build job to the queue on a cluster, we can skip the necessary user interaction with this added option.