### PR TITLE
Update arapck-ng version 3.6.2 to 3.8.0

### DIFF
--- a/deal.II-toolchain/packages/arpack-ng.package
+++ b/deal.II-toolchain/packages/arpack-ng.package
@@ -1,4 +1,4 @@
-VERSION=3.6.2
+VERSION=3.8.0
 NAME=arpack-ng.git
 EXTRACTSTO=arpack-ng-${VERSION}
 SOURCE=https://github.com/opencollab/


### PR DESCRIPTION
Using version 3.6.2 throws an error while compiling. This can easily be resolved with updating the version to 3.8.0.