### PR TITLE
Update to latest arpack version 3.8.0

### DIFF
--- a/deal.II-toolchain/packages/arpack-ng.package
+++ b/deal.II-toolchain/packages/arpack-ng.package
@@ -1,4 +1,4 @@
-VERSION=3.6.2
+VERSION=3.8.0
 NAME=arpack-ng.git
 EXTRACTSTO=arpack-ng-${VERSION}
 SOURCE=https://github.com/opencollab/


### PR DESCRIPTION
This updates to the latest arpack-ng version since 3.6.2 failed on my system, compare #168.