### PR TITLE
Option whether to build dealii examples

### DIFF
--- a/candi.cfg
+++ b/candi.cfg
@@ -31,6 +31,9 @@ DEAL_CONFOPTS=""
 # enable machine-specific optimizations (implies -march=native etc.)?
 #NATIVE_OPTIMIZATIONS=true
 
+# enable building of dealii examples
+BUILD_EXAMPLES=true
+
 # Choose the python interpreter to use. We pick python2, python3,
 # python in that order by default. If you want to override this
 # choice, uncomment the following:

--- a/deal.II-toolchain/packages/dealii.package
+++ b/deal.II-toolchain/packages/dealii.package
@@ -26,6 +26,18 @@ CONFOPTS=" \
 -D DEAL_II_FORCE_BUNDLED_BOOST:BOOL=OFF \
 -D DEAL_II_WITH_ZLIB:BOOL=ON"
 
+# Choice of whether to build the dealii examples
+if [ "${BUILD_EXAMPLES}" = "true" ]; then
+    CONFOPTS="${CONFOPTS} \
+      -D DEAL_II_COMPONENT_EXAMPLES:BOOL=ON"
+elif [ "${BUILD_EXAMPLES}" = "false" ]; then
+    CONFOPTS="${CONFOPTS} \
+      -D DEAL_II_COMPONENT_EXAMPLES:BOOL=OFF"
+else
+    cecho ${BAD} "candi: bad variable: BUILD_EXAMPLES={false|true}; (your specified option is = ${BUILD_EXAMPLES})"
+    exit 1
+fi
+
 if [ "${NATIVE_OPTIMIZATIONS}" = "true" ]; then
     CONFOPTS="${CONFOPTS} \
       -D CMAKE_CXX_FLAGS='-march=native'"


### PR DESCRIPTION
In my experience, building the dealii tutorials is quite time consuming and if one specific is needed it can be build on demand in a local workdir. So this option allows a flag whether to enable or disable the build of the dealii tutorials.

Personally, I would also be interested in how to set up the continuous integration for testing this (i.e. how to test both cases true|false).