### PR TITLE
Update cmake to version 3.16.3

### DIFF
--- a/deal.II-toolchain/packages/cmake.package
+++ b/deal.II-toolchain/packages/cmake.package
@@ -1,5 +1,5 @@
-MAJOR=3.11
-MINOR=2
+MAJOR=3.16
+MINOR=3
 VERSION=${MAJOR}.${MINOR}
 
 # We try to determine if we have a linux platform to use tarball install
@@ -16,13 +16,15 @@ if [ ${PLATFORM_OSTYPE} == "linux" ]; then
     # tarball install
     NAME=cmake-${VERSION}-Linux-x86_64
     PACKING=.tar.gz
-    CHECKSUM=55e30dd01698e9409b576008fd22394c
+    # CHECKSUM=55e30dd01698e9409b576008fd22394c # 3.11.2
+    CHECKSUM=8f3dd8952ae9d532ae340c7d0f4cd1d7 # 3.16.3
     BUILDCHAIN=ignore
 else
     # configure/make/install
     NAME=cmake-${VERSION}
     PACKING=.tar.gz
-    CHECKSUM=d2d554c05fc07cfae7846d2aa205f12a
+    # CHECKSUM=d2d554c05fc07cfae7846d2aa205f12a # 3.11.2
+    CHECKSUM=9e6fa59704d3a52812e279996b5b01c7 # 3.16.3
 
     if builtin command -v cmake > /dev/null; then
         # configure/make with cmake (older or newer version already installed)    
@@ -56,4 +58,3 @@ export PATH=${INSTALL_PATH}/bin:\${PATH}
 export CMAKE_ROOT=${INSTALL_PATH}/share/${MAJOR}
 " >> $CONFIG_FILE
 }
-


### PR DESCRIPTION
This updates the bundled cmake installation to version 3.16.3. At the moment, the Ubuntu 20.04 CI tests the cmake package.