### PR TITLE
Add option to run tests after installation

### DIFF
--- a/candi.cfg
+++ b/candi.cfg
@@ -35,7 +35,7 @@ DEAL_CONFOPTS=""
 BUILD_EXAMPLES=true
 
 # Option {ON|OFF}: Run tests after installation?
-RUN_DEAL_II_TESTS=ON
+RUN_DEAL_II_TESTS=OFF
 
 # Choose the python interpreter to use. We pick python2, python3,
 # python in that order by default. If you want to override this

--- a/candi.cfg
+++ b/candi.cfg
@@ -34,6 +34,9 @@ DEAL_CONFOPTS=""
 # enable building of dealii examples
 BUILD_EXAMPLES=true
 
+# Option {ON|OFF}: Run tests after installation?
+RUN_DEAL_II_TESTS=ON
+
 # Choose the python interpreter to use. We pick python2, python3,
 # python in that order by default. If you want to override this
 # choice, uncomment the following:

--- a/deal.II-toolchain/packages/dealii.package
+++ b/deal.II-toolchain/packages/dealii.package
@@ -224,6 +224,14 @@ fi
 
 ################################################################################
 
+package_specific_install() {
+    if [ ${RUN_DEAL_II_TESTS} = ON ]; then
+        make test 2>&1 | tee candi_test.log
+    fi
+}
+
+
+
 package_specific_conf() {
     ############################################################################
     # Generate modulefile


### PR DESCRIPTION
This adds an option RUN_DEAL_II_TESTS={ON|OFF} to the configureation file to run the dealii tests (make test) after installation.