### PR TITLE
Clean up option

### DIFF
--- a/candi.cfg
+++ b/candi.cfg
@@ -119,11 +119,11 @@ DEVELOPER_MODE=OFF
 ################################################################################
 
 # OPTION {ON|OFF}: Remove build directory after successful installation
-INSTANT_CLEAN_BUILD_AFTER_INSTALL=ON
+INSTANT_CLEAN_BUILD_AFTER_INSTALL=OFF
 
 # OPTION {ON|OFF}: Remove downloaded packed src after successful installation
-INSTANT_CLEAN_SRC_AFTER_INSTALL=ON
+INSTANT_CLEAN_SRC_AFTER_INSTALL=OFF
 
 # OPTION {ON|OFF}: Remove unpack directory after successful installation
-INSTANT_CLEAN_UNPACK_AFTER_INSTALL=ON
+INSTANT_CLEAN_UNPACK_AFTER_INSTALL=OFF
 

--- a/candi.cfg
+++ b/candi.cfg
@@ -18,11 +18,6 @@ CLEAN_BUILD=false
 # Where do you want the compiled software installed?
 INSTALL_PATH=${PREFIX_PATH}
 
-# OPTION {ON|OFF}: Clean install directory after successful installation by
-# removing the build directory, the unpacked source files and (if available)
-# the downloaded packed source file.
-INSTANT_CLEAN_AFTER_INSTALL=OFF
-
 #########################################################################
 # Set up mirror server url(s), to speed up downloads, e.g.
 #   MIRROR="${MIRROR} http://server1.org/package_mirror_dir/"
@@ -120,4 +115,15 @@ MKL=OFF
 # Note: a previous run of candi with the same settings must be done without
 #       this mode!
 DEVELOPER_MODE=OFF
+
+################################################################################
+
+# OPTION {ON|OFF}: Remove build directory after successful installation
+INSTANT_CLEAN_BUILD_AFTER_INSTALL=ON
+
+# OPTION {ON|OFF}: Remove downloaded packed src after successful installation
+INSTANT_CLEAN_SRC_AFTER_INSTALL=ON
+
+# OPTION {ON|OFF}: Remove unpack directory after successful installation
+INSTANT_CLEAN_UNPACK_AFTER_INSTALL=ON
 

--- a/candi.cfg
+++ b/candi.cfg
@@ -18,8 +18,10 @@ CLEAN_BUILD=false
 # Where do you want the compiled software installed?
 INSTALL_PATH=${PREFIX_PATH}
 
-# OPTION {ON|OFF}: Clean install directory after successful installation
-CLEAN_INSTALL_DIR=OFF
+# OPTION {ON|OFF}: Clean install directory after successful installation by
+# removing the build directory, the unpacked source files and (if available)
+# the downloaded packed source file.
+INSTANT_CLEAN_AFTER_INSTALL=OFF
 
 #########################################################################
 # Set up mirror server url(s), to speed up downloads, e.g.

--- a/candi.cfg
+++ b/candi.cfg
@@ -18,6 +18,9 @@ CLEAN_BUILD=false
 # Where do you want the compiled software installed?
 INSTALL_PATH=${PREFIX_PATH}
 
+# OPTION {ON|OFF}: Clean install directory after successful installation
+CLEAN_INSTALL_DIR=OFF
+
 #########################################################################
 # Set up mirror server url(s), to speed up downloads, e.g.
 #   MIRROR="${MIRROR} http://server1.org/package_mirror_dir/"

--- a/candi.sh
+++ b/candi.sh
@@ -1148,6 +1148,15 @@ for PACKAGE in ${PACKAGES[@]}; do
     TIMINGS="$TIMINGS"$"\n""$PACKAGE: ""$((TOC)) s"
 done
 
+# Cleanup install directory on demand
+if [ ${CLEAN_INSTALL_DIR} = ON ]; then
+    echo
+    echo "Removing all temporary installation files/directories"
+    rm -rf ${PREFIX_PATH}/tmp
+    cecho ${GOOD} "Done"
+    echo
+fi
+
 # print information about enable.sh
 echo
 echo To export environment variables for all installed libraries execute:

--- a/candi.sh
+++ b/candi.sh
@@ -1131,11 +1131,21 @@ for PACKAGE in ${PACKAGES[@]}; do
         fi
         package_build
 
-        # Clean build/src/unpack directory after install
-        if [ ${INSTANT_CLEAN_AFTER_INSTALL} = ON ]; then
-            rm -rf ${BUILDDIR} # build
-            rm -rf ${DOWNLOAD_PATH}/${NAME}${PACKING} # src
-            rm -rf ${UNPACK_PATH}/${EXTRACTSTO} # unpack
+        # Clean build directory after install
+        if [ ${INSTANT_CLEAN_BUILD_AFTER_INSTALL} = ON ]; then
+            rm -rf ${BUILDDIR}
+        fi
+
+        # Clean src after install
+        if [ ${INSTANT_CLEAN_SRC_AFTER_INSTALL} = ON ]; then
+            if [ -f ${DOWNLOAD_PATH}/${NAME}${PACKING} ]; then
+                rm -f ${DOWNLOAD_PATH}/${NAME}${PACKING}
+            fi
+        fi
+
+        # Clean unpack directory after install
+        if [ ${INSTANT_CLEAN_UNPACK_AFTER_INSTALL} = ON ]; then
+            rm -rf ${UNPACK_PATH}/${EXTRACTSTO}
         fi
     else
         if [ ! -z "${LOAD}" ]; then

--- a/candi.sh
+++ b/candi.sh
@@ -1130,6 +1130,13 @@ for PACKAGE in ${PACKAGES[@]}; do
             package_unpack
         fi
         package_build
+
+        # Clean build/src/unpack directory after install
+        if [ ${INSTANT_CLEAN_AFTER_INSTALL} = ON ]; then
+            rm -rf ${BUILDDIR} # build
+            rm -rf ${DOWNLOAD_PATH}/${NAME}${PACKING} # src
+            rm -rf ${UNPACK_PATH}/${EXTRACTSTO} # unpack
+        fi
     else
         if [ ! -z "${LOAD}" ]; then
             # Let the user know we're loading the current package
@@ -1146,14 +1153,6 @@ for PACKAGE in ${PACKAGES[@]}; do
     # Store timing
     TOC="$(($(${DATE_CMD} +%s)-TIC))"
     TIMINGS="$TIMINGS"$"\n""$PACKAGE: ""$((TOC)) s"
-
-    # Cleanup install directory on demand
-    if [ ${CLEAN_INSTALL_DIR} = ON ]; then
-        echo
-        echo "Removing temporary installation files/directories"
-        rm -rf ${PREFIX_PATH}/tmp
-        echo
-    fi
 done
 
 # print information about enable.sh

--- a/candi.sh
+++ b/candi.sh
@@ -1146,16 +1146,15 @@ for PACKAGE in ${PACKAGES[@]}; do
     # Store timing
     TOC="$(($(${DATE_CMD} +%s)-TIC))"
     TIMINGS="$TIMINGS"$"\n""$PACKAGE: ""$((TOC)) s"
-done
 
-# Cleanup install directory on demand
-if [ ${CLEAN_INSTALL_DIR} = ON ]; then
-    echo
-    echo "Removing all temporary installation files/directories"
-    rm -rf ${PREFIX_PATH}/tmp
-    cecho ${GOOD} "Done"
-    echo
-fi
+    # Cleanup install directory on demand
+    if [ ${CLEAN_INSTALL_DIR} = ON ]; then
+        echo
+        echo "Removing temporary installation files/directories"
+        rm -rf ${PREFIX_PATH}/tmp
+        echo
+    fi
+done
 
 # print information about enable.sh
 echo


### PR DESCRIPTION
This option removes the tmp dir after each successful package installation. The idea is to minimize the disk usage during installation. Therefore the tmp dir is removed several time instead only once in the end (out of the loop).