### PR TITLE
on the master branch always use dev deal.II version

### DIFF
--- a/candi.cfg
+++ b/candi.cfg
@@ -79,8 +79,8 @@ PACKAGES="${PACKAGES} dealii"
 
 #########################################################################
 
-# Install the following deal.II version:
-DEAL_II_VERSION=v9.2.0
+# Install the following deal.II version (choose master v9.3.0 ...)
+DEAL_II_VERSION=master
 
 #########################################################################
 


### PR DESCRIPTION
it makes sense to test the latest deal.II master version on the candi
master branch (in contrast to the 9.x branches)