### PR TITLE
Extend gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,26 @@
-*~
+# candi/tmp directories
 /src/
 /deal.II-toolchain-build/
 /deal.II-toolchain-unpack/
-*.DS_Store
+
+# eclipse
+/.cproject
+/.project
+qtcreator/
+
+# visual studio code
+/.vscode
+
+# temporary and backup files
+*~
+*#
+*.swp
+
+# MacOS self-generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db


### PR DESCRIPTION
I was annoyed, that my .vscode dir was always listed in git status, so I copied some lines from the gitignore file of dealii/dealii. Please tell me if some files are too much. @koecher were the candi/tmp dirs (I commented them this way) for your personal folder structure (originally?)