### PR TITLE
only set MPI_CXX_COMPILER if requested

### DIFF
--- a/candi.cfg
+++ b/candi.cfg
@@ -36,6 +36,12 @@ NATIVE_OPTIMIZATIONS=OFF
 # Option {ON|OFF}: Enable building of dealii examples?
 BUILD_EXAMPLES=ON
 
+# Option {ON|OFF}: Unset CXX and set the compiler as MPI_CXX_COMPILER when configuring deal.II
+#
+# This is recommended for very recent CMake versions but it currently is not reliable enough
+# to enable by default.
+USE_DEAL_II_CMAKE_MPI_COMPILER=OFF
+
 # Option {ON|OFF}: Run tests after installation?
 RUN_DEAL_II_TESTS=OFF
 

--- a/deal.II-toolchain/packages/dealii.package
+++ b/deal.II-toolchain/packages/dealii.package
@@ -18,8 +18,6 @@ INSTALL_PATH=${ORIG_INSTALL_PATH}/deal.II-${VERSION}
 CONFOPTS=" \
 -D CMAKE_BUILD_TYPE=DebugRelease \
 -D DEAL_II_WITH_MPI:BOOL=ON \
--D MPI_CXX_COMPILER=${CXX} \
--D MPI_C_COMPILER=${CC} \
 -D DEAL_II_COMPONENT_DOCUMENTATION:BOOL=OFF \
 -D DEAL_II_WITH_LAPACK:BOOL=ON \
 -D DEAL_II_WITH_UMFPACK:BOOL=ON \
@@ -43,15 +41,21 @@ if [ ${NATIVE_OPTIMIZATIONS} = ON ]; then
       -D CMAKE_CXX_FLAGS='-march=native'"
 fi
 
+if [ ${USE_DEAL_II_CMAKE_MPI_COMPILER} = ON ]; then
+    # Disable CXX, CC for deal.II as recommended in
+    # https://github.com/dealii/dealii/issues/11478 and set MPI_*_COMPILER
+    # cmake variables. This only works for recent CMake versions.
+    CONFOPTS="${CONFOPTS} \
+    -D MPI_CXX_COMPILER=${CXX} \
+    -D MPI_C_COMPILER=${CC}"
+
+    unset CXX
+    unset CC
+fi
+
 # add the user-specified flags at the end (so things can be overriden):
 CONFOPTS="${CONFOPTS} \
 ${DEAL_II_CONFOPTS}"
-
-# Disable CXX, CC for deal.II as recommended in
-# https://github.com/dealii/dealii/issues/11478 . Note the we are
-# setting the MPI_*_COMPILER cmake variables above.
-unset CXX
-unset CC
 
 ################################################################################
 # Check if we hit cmake-3.10+ and deal.II v8.5.1 configure error (MPI / FindMPI)


### PR DESCRIPTION
Setting the compiler wrapper in CMake instead of in CC and CXX is
recommended, but only works for recent CMake versions (one configuration
I tested requires CMake 3.20 for the intel compiler).
With 9.3.1 deal.II supports setting CXX=mpicxx again, so only do the
above when a setting in candi.cfg is specified.
Works around #202
and fixes feature introduced in #159