### PR TITLE
Update default install prefix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         echo 'DEAL_II_CONFOPTS="-D CMAKE_BUILD_TYPE=Debug"' >> candi.cfg
         ./candi.sh -j 2 --packages="once:p4est dealii"
-        cd ~/deal.ii-candi/tmp/build/deal.II-* && cat detailed.log && make test
+        cd ~/dealii-candi/tmp/build/deal.II-* && cat detailed.log && make test
 
   ubuntu20-blas:
     name: ubuntu 20.04
@@ -41,7 +41,7 @@ jobs:
       run: |
         # use our cmake version, as the runner has 3.19 installed, which is too new for deal.II
         ./candi.sh -j 2 --packages="once:cmake once:openblas once:p4est dealii"
-        cd ~/deal.ii-candi/tmp/build/deal.II-* && cat detailed.log && make test
+        cd ~/dealii-candi/tmp/build/deal.II-* && cat detailed.log && make test
 
   osx-minimal:
     name: OSX clang
@@ -63,7 +63,7 @@ jobs:
       run: |
         echo 'DEAL_II_CONFOPTS="-D CMAKE_BUILD_TYPE=Debug"' >> candi.cfg
         ./candi.sh -j 2 --packages="dealii"
-        cd ~/deal.ii-candi/tmp/build/deal.II-* && cat detailed.log && make test
+        cd ~/dealii-candi/tmp/build/deal.II-* && cat detailed.log && make test
 
   osx-gcc:
     name: OSX gcc
@@ -89,4 +89,4 @@ jobs:
         export OMPI_FC=gfortran-9
         echo 'DEAL_II_CONFOPTS="-D CMAKE_BUILD_TYPE=Debug"' >> candi.cfg
         ./candi.sh -j 2 --packages="once:p4est once:petsc dealii"
-        cd ~/deal.ii-candi/tmp/build/deal.II-* && cat detailed.log && make test
+        cd ~/dealii-candi/tmp/build/deal.II-* && cat detailed.log && make test

--- a/candi.sh
+++ b/candi.sh
@@ -39,7 +39,7 @@ TIC_GLOBAL="$(${DATE_CMD} +%s)"
 
 ################################################################################
 # Parse command line input parameters
-PREFIX=~/deal.ii-candi
+PREFIX=~/dealii-candi
 JOBS=1
 CMD_PACKAGES=""
 USER_INTERACTION=ON


### PR DESCRIPTION
I assume you use a manually specified install dir? However, for consistency I would like to suggest changing the default install path to either deal.II-candi or dealii-candi. Personally I like dealii-candi, as no dots are in this name.