### PR TITLE
Update package adolc

### DIFF
--- a/deal.II-toolchain/packages/adolc.package
+++ b/deal.II-toolchain/packages/adolc.package
@@ -1,27 +1,30 @@
-# use development version?
-CANDI_ADOLC_FROM_GIT=1
+################################################################################
+## ADOLC                                                                      ##
+################################################################################
 
-if [ -n "$CANDI_ADOLC_FROM_GIT" ]; then
+# Option {ON|OFF}: Choose whether to load the tarball or the git repository.
+CANDI_ADOLC_LOAD_TARBALL=ON
+
+if [ ${CANDI_ADOLC_LOAD_TARBALL} = ON ]; then
+    # download release tarball
+    VERSION=2.7.2
+    CHECKSUM=701e0856baae91b98397960d5e0a87a549988de9d4002d0e9a56fa08f5455f6e
+    CHECKSUM="${CHECKSUM} 372c86eaa8b11f83825b2d9e0719b5ce3cb7066d"
+    CHECKSUM="${CHECKSUM} ea05bd8e0d6c92d474204876fdcad04d"
+
+    NAME=${VERSION}
+    SOURCE=https://github.com/coin-or/ADOL-C/archive/releases/
+    EXTRACTSTO=ADOL-C-releases-${VERSION}
+    PACKING=.tar.gz
+else
     # download git repository
     VERSION=master
-    EXTRACTSTO=ADOL-C-master
-
     NAME=ADOL-C.git
-    PACKING=git
     SOURCE=https://github.com/coin-or/
-
-else
-    # download release tarball
-
-    VERSION=2.7.2
-    NAME=${VERSION}
-    EXTRACTSTO=ADOL-C-releases-${VERSION}
-    SOURCE=https://github.com/coin-or/ADOL-C/archive/releases/
-    CHECKSUM=ea05bd8e0d6c92d474204876fdcad04d
-    PACKING=.tar.gz
+    EXTRACTSTO=ADOL-C-master
+    PACKING=git
 fi
-unset CANDI_ADOLC_FROM_GIT
-
+unset CANDI_ADOLC_LOAD_TARBALL
 
 BUILDCHAIN=autotools
 
@@ -37,7 +40,7 @@ package_specific_register () {
 package_specific_conf () {
     # Generate configuration file
     CONFIG_FILE=${CONFIGURATION_PATH}/adolc-${VERSION}
-    rm -f $CONFIG_FILE
+    rm -f ${CONFIG_FILE}
     echo "
 export ADOLC_DIR=${INSTALL_PATH}
 " >> $CONFIG_FILE

--- a/deal.II-toolchain/packages/dealii.package
+++ b/deal.II-toolchain/packages/dealii.package
@@ -274,6 +274,21 @@ if [ ! -z "${GMSH_DIR}" ]; then
       -D GMSH_DIR=${GMSH_DIR}"
 fi
 
+########################################
+# ADOLC
+if [[ ${PACKAGES_OFF} =~ 'adolc' ]]; then
+    if [ ! -z "${ADOLC_DIR}" ]; then
+        cecho ${INFO} "deal.II: unset ADOLC_DIR due to forced DEAL_II_WITH_ADOLC:BOOL=OFF option"
+        unset ADOLC_DIR
+    fi
+fi
+
+if [ ! -z "${ADOLC_DIR}" ]; then
+    cecho ${INFO} "deal.II: configuration with ADOLC"
+    CONFOPTS="${CONFOPTS} \
+      -D DEAL_II_WITH_ADOLC:BOOL=ON"
+fi
+
 ################################################################################
 
 package_specific_install() {


### PR DESCRIPTION
Update the checksums for ADOL-C and enable tarball download by default. Test is currently running via github actions in my fork, see https://github.com/gfcas/candi/actions/runs/982865293