### PR TITLE
Update arpackg-ng package

### DIFF
--- a/deal.II-toolchain/packages/arpack-ng.package
+++ b/deal.II-toolchain/packages/arpack-ng.package
@@ -1,3 +1,7 @@
+################################################################################
+## ARPACK-NG                                                                  ##
+################################################################################
+
 VERSION=3.8.0
 NAME=arpack-ng.git
 EXTRACTSTO=arpack-ng-${VERSION}
@@ -9,21 +13,20 @@ BUILDDIR=${BUILD_PATH}/arpack-ng-${VERSION}
 INSTALL_PATH=${INSTALL_PATH}/arpack-ng-${VERSION}
 
 CONFOPTS="\
- -D CMAKE_INSTALL_LIBDIR=$INSTALL_PATH/lib \
- -D EXAMPLES=OFF \
- -D MPI=ON \
- -D BUILD_SHARED_LIBS=ON"
+  -D CMAKE_INSTALL_LIBDIR=${INSTALL_PATH}/lib \
+  -D EXAMPLES:BOOL=OFF \
+  -D MPI:BOOL=ON \
+  -D BUILD_SHARED_LIBS:BOOL=ON"
 
-package_specific_register () {
-    export ARPACK_DIR=${INSTALL_PATH}
+package_specific_register() {
+  export ARPACK_DIR=${INSTALL_PATH}
 }
 
-package_specific_conf () {
-    # Generate configuration file
-    CONFIG_FILE=${CONFIGURATION_PATH}/${NAME}
-    rm -f $CONFIG_FILE
-    echo "
+package_specific_conf() {
+  # Generate configuration file
+  CONFIG_FILE=${CONFIGURATION_PATH}/${NAME}
+  rm -f $CONFIG_FILE
+  echo "
 export ARPACK_DIR=${INSTALL_PATH}
-" >> $CONFIG_FILE
+" >>$CONFIG_FILE
 }
-

--- a/deal.II-toolchain/packages/dealii.package
+++ b/deal.II-toolchain/packages/dealii.package
@@ -85,17 +85,24 @@ fi
 ################################################################################
 # Add additional packages, if present
 
-# arpack
+########################################
+# ARPACK
+if [[ ${PACKAGES_OFF} =~ 'arpack-ng' ]]; then
+    if [ ! -z "${ARPACK_DIR}" ]; then
+        cecho ${INFO} "deal.II: unset ARPACK_DIR due to forced DEAL_II_WITH_ARPACK:BOOL=OFF option"
+        unset ARPACK_DIR
+    fi
+fi
+
 if [ ! -z "${ARPACK_DIR}" ]; then
     cecho ${INFO} "deal.II: configuration with ARPACK"
     # We use a recent enough version of arpack, so PARPACK can be enabled
     # even though it is disabled by default, see 
     # https://github.com/dealii/dealii/blob/master/cmake/modules/FindARPACK.cmake
-    CONFOPTS="\
-        ${CONFOPTS} \
-        -D DEAL_II_WITH_ARPACK:BOOL=ON \
-        -D DEAL_II_ARPACK_WITH_PARPACK=ON \
-        -D ARPACK_DIR=${ARPACK_DIR}"
+    CONFOPTS="${CONFOPTS} \
+      -D DEAL_II_WITH_ARPACK:BOOL=ON \
+      -D DEAL_II_ARPACK_WITH_PARPACK:BOOL=ON \
+      -D ARPACK_DIR=${ARPACK_DIR}"
 fi
 
 # metis


### PR DESCRIPTION
This updates the arpack package file. Up to minor indention fixes afterwards the tests on Ubuntu were OK (https://github.com/gfcas/candi/actions/runs/986593992). However, testing it with the OSX-clang setup (see main.yml) an error is throw during the arpack configuration:
```
The Fortran compiler

    "/usr/local/bin/mpif90"

  is not able to compile a simple test program.
```