### PR TITLE
Trilinos: add complex option

### DIFF
--- a/candi.cfg
+++ b/candi.cfg
@@ -98,6 +98,11 @@ TRILINOS_MAJOR_VERSION=AUTO
 #TRILINOS_MAJOR_VERSION=12
 #TRILINOS_MAJOR_VERSION=11
 
+# If enabled, Trilinos is configured with complex number support in
+# Teuchos and Tpetra. This takes a long time to compile and requires a
+# lot of RAM. It is also likely not something you will need.
+TRILINOS_WITH_COMPLEX=OFF
+
 #########################################################################
 
 # Option {ON|OFF}: Do you want to use MKL?

--- a/deal.II-toolchain/packages/trilinos.package
+++ b/deal.II-toolchain/packages/trilinos.package
@@ -183,16 +183,10 @@ CONFOPTS="\
   -D Trilinos_ENABLE_Ifpack:BOOL=ON \
   -D Trilinos_ENABLE_Ifpack2:BOOL=OFF \
   -D Trilinos_ENABLE_Tpetra:BOOL=ON \
-  -D   Tpetra_INST_DOUBLE:BOOL=ON \
   -D   Tpetra_INST_INT_LONG:BOOL=ON \
-  -D   Tpetra_INST_COMPLEX_DOUBLE:BOOL=ON \
-  -D   Tpetra_INST_COMPLEX_FLOAT:BOOL=ON \
-  -D   Tpetra_INST_FLOAT:BOOL=ON \
-  -D   Tpetra_INST_SERIAL:BOOL=ON \
   -D Trilinos_ENABLE_AztecOO:BOOL=ON \
   -D Trilinos_ENABLE_Sacado:BOOL=ON \
   -D Trilinos_ENABLE_Teuchos:BOOL=ON \
-  -D   Teuchos_ENABLE_COMPLEX:BOOL=ON \
   -D   Teuchos_ENABLE_FLOAT:BOOL=ON \
   -D Trilinos_ENABLE_MueLu:BOOL=ON \
   -D Trilinos_ENABLE_ML:BOOL=ON \
@@ -205,7 +199,18 @@ CONFOPTS="\
   -D CMAKE_BUILD_TYPE:STRING=RELEASE \
   -D CMAKE_VERBOSE_MAKEFILE:BOOL=OFF \
   -D BUILD_SHARED_LIBS:BOOL=ON \
-  ${CONFOPTS} \
+  ${CONFOPTS}"
+
+if [ ${TRILINOS_WITH_COMPLEX} = ON ]; then
+    CONFOPTS="\
+    -D Trilinos_ENABLE_COMPLEX_DOUBLE=ON \
+    -D Trilinos_ENABLE_COMPLEX_FLOAT=ON \
+    -D Teuchos_ENABLE_COMPLEX:BOOL=ON \
+    ${CONFOPTS}"
+fi
+
+# finally append user options:
+CONFOPTS="${CONFOPTS} \
   ${TRILINOS_CONFOPTS}"
 
 package_specific_register () {


### PR DESCRIPTION
Trilinos complex support is not needed in deal.II, unless complex Tpetra
vectors are used (unlikely). Enabling it requires large amounts of RAM
(we are talking 10GB per process). Instead, introduce an option that
defaults to OFF.

Also do not specify Tpetra_INST_* see https://github.com/dealii/dealii/pull/8945
fixes #219