### PR TITLE
Enable trilinos explicit instantiations

### DIFF
--- a/deal.II-toolchain/packages/trilinos.package
+++ b/deal.II-toolchain/packages/trilinos.package
@@ -180,6 +180,7 @@ CONFOPTS="\
   -D Trilinos_ENABLE_Amesos:BOOL=ON \
   -D Trilinos_ENABLE_Epetra:BOOL=ON \
   -D Trilinos_ENABLE_EpetraExt:BOOL=ON \
+  -D Trilinos_ENABLE_EXPLICIT_INSTANTIATION=ON \
   -D Trilinos_ENABLE_Ifpack:BOOL=ON \
   -D Trilinos_ENABLE_Ifpack2:BOOL=OFF \
   -D Trilinos_ENABLE_Tpetra:BOOL=ON \


### PR DESCRIPTION
What about this change to solve #219? All explicit instantiations in all trilinos subpackages are disabled by default. Switching this variable enables them for all active packages (I checked the cmake variables in my build, off before, on now). Memory requirements dropped for me, and compile time seemed somewhat faster as well.

The largest compilation unit I have seen was 3.5GB (down from 8GB) and most are now much smaller than that. At the moment I am compiling without complex instantiations though (can try again tomorrow with default if you want).

I also found this: https://github.com/trilinos/Trilinos/issues/8130, so maybe for future trilinos versions we do not need this anymore because trilinos changed its default for new versions (probably the next one after 13.0?)