### PR TITLE
Update sundials package

### DIFF
--- a/deal.II-toolchain/packages/dealii.package
+++ b/deal.II-toolchain/packages/dealii.package
@@ -297,6 +297,22 @@ if [ ! -z "${ADOLC_DIR}" ]; then
       -D ADOLC_DIR=${ADOLC_DIR}"
 fi
 
+########################################
+# SUNDIALS
+if [[ ${PACKAGES_OFF} =~ 'sundials' ]]; then
+    if [ ! -z "${SUNDIALS_DIR}" ]; then
+        cecho ${INFO} "deal.II: unset SUNDIALS_DIR due to forced DEAL_II_WITH_SUNDIALS:BOOL=OFF option"
+        unset SUNDIALS_DIR
+    fi
+fi
+
+if [ ! -z "${SUNDIALS_DIR}" ]; then
+    cecho ${INFO} "deal.II: configuration with SUNDIALS"
+    CONFOPTS="${CONFOPTS} \
+      -D DEAL_II_WITH_SUNDIALS:BOOL=ON \
+      -D SUNDIALS_DIR=${SUNDIALS_DIR}"
+fi
+
 ################################################################################
 package_specific_install() {
     if [ ${RUN_DEAL_II_TESTS} = ON ]; then

--- a/deal.II-toolchain/packages/sundials.package
+++ b/deal.II-toolchain/packages/sundials.package
@@ -1,28 +1,59 @@
-VERSION=3.1.0
-NAME=sundials-${VERSION}
-EXTRACTSTO=sundials-${VERSION}
-SOURCE=https://computation.llnl.gov/projects/sundials/download/
-CHECKSUM=1a84ca41c7f71067e03d519ddbcd9dae
-PACKING=.tar.gz
+################################################################################
+## SUNDIALS                                                                   ##
+################################################################################
+
+# By default load the tarball.
+# To load the git repository define a variable CANDI_SUNDIALS_LOAD_TARBALL=OFF.
+if [ -z ${CANDI_SUNDIALS_LOAD_TARBALL} ]; then
+    CANDI_SUNDIALS_LOAD_TARBALL=ON
+fi
+
+if [ ${CANDI_SUNDIALS_LOAD_TARBALL} = ON ]; then
+    # 2021/07/01
+    VERSION=5.7.0
+    CHECKSUM=48da7baa8152ddb22aed1b02d82d1dbb4fbfea22acf67634011aa0303a100a43
+    CHECKSUM="${CHECKSUM} c04ecc9102851955b62e626a43ad5f604e890ab0"
+    CHECKSUM="${CHECKSUM} 483784dab433f178e79072bbed98c38c"
+
+    # VERSION=3.1.0
+    # CHECKSUM=1a84ca41c7f71067e03d519ddbcd9dae
+
+    NAME=sundials-${VERSION}
+    PACKING=.tar.gz
+    EXTRACTSTO=sundials-${VERSION}
+    SOURCE=https://github.com/LLNL/sundials/releases/download/v${VERSION}/
+else
+
+    VERSION=v5.7.0
+    # VERSION=v3.2.1
+
+    NAME=sundials
+    PACKING=git
+    SOURCE=https://github.com/LLNL/
+    EXTRACTSTO=${NAME}-${VERSION}
+fi
+unset CANDI_SUNDIALS_LOAD_TARBALL
+
 BUILDCHAIN=cmake
 
 BUILDDIR=${BUILD_PATH}/sundials-${VERSION}
 INSTALL_PATH=${INSTALL_PATH}/sundials-${VERSION}
 
-CONFOPTS="-D CMAKE_INSTALL_PREFIX=${INSTALL_PATH} \
- -D MPI_ENABLE=ON \
- -D BUILD_SHARED_LIBS=ON"
+# In versions prior to v5.7.0 the deprecated options MPI_ENABLE instead of the
+# new ENABLE_MPI option was used.
+CONFOPTS="\
+  -D ENABLE_MPI:BOOL=ON \
+  -D BUILD_SHARED_LIBS:BOOL=ON"
 
-package_specific_register () {
+package_specific_register() {
     export SUNDIALS_DIR=${INSTALL_PATH}
 }
 
-package_specific_conf () {
+package_specific_conf() {
     # Generate configuration file
     CONFIG_FILE=${CONFIGURATION_PATH}/${NAME}
     rm -f $CONFIG_FILE
     echo "
 export SUNDIALS_DIR=${INSTALL_PATH}
-" >> $CONFIG_FILE
+" >>$CONFIG_FILE
 }
-


### PR DESCRIPTION
Update of the SUNDIALS package file:
- Enable switch between tarball(default) and git download
- The source webpage for tarball download was deprecated
- The CONFOPT ``MPI_ENABLE`` was replaced by ``ENABLE_MPI`` (Unfortunately I dont know with which version this change is beginning, however, a deprecation warning is given on the terminal)
- Update to the latest stable release 5.7.0
- CI for sundials+dealii see https://github.com/gfcas/candi/actions/runs/1001803067