### PR TITLE
Add Debian 10 as supported platform and add missing package for SymEngine

### DIFF
--- a/deal.II-toolchain/platforms/supported/centos7.platform
+++ b/deal.II-toolchain/platforms/supported/centos7.platform
@@ -11,7 +11,8 @@
 # libtool libtool-ltdl libtool-ltdl-devel \
 # lua lua-devel \
 # blas blas-devel lapack lapack-devel \
-# doxygen graphviz graphviz-devel qt-devel
+# doxygen graphviz graphviz-devel qt-devel \
+# gmp-devel
 # 
 # Be sure to switch to the recent compilers with
 # $ scl enable devtoolset-9 bash 

--- a/deal.II-toolchain/platforms/supported/debian10.platform
+++ b/deal.II-toolchain/platforms/supported/debian10.platform
@@ -1,0 +1,24 @@
+# debian 10
+#
+# This build script assumes that you have several packages already
+# installed via debian's apt-get using the following commands:
+#
+# > sudo apt-get install build-essential automake autoconf gfortran \
+#   openmpi-bin openmpi-common libopenmpi-dev cmake subversion git \
+#   libblas-dev liblapack-dev libblas3 liblapack3 splint tcl tcl-dev \
+#   environment-modules libsuitesparse-dev libtool libboost-all-dev \
+#   qt4-dev-tools libgmp-dev
+#
+# Then reboot and run candi again.
+##
+
+# on debian 10 the candi installed parmetis 4.0.3 is not recognized correctly
+# for trilinos 12-10-1. We force to assume parmetis version 4.0.3.
+TRILINOS_PARMETIS_CONFOPTS="\
+    ${TRILINOS_PARMETIS_CONFOPTS} \
+    -D HAVE_PARMETIS_VERSION_4_0_3=ON"
+
+#
+# Define the additional packages for this platform.
+#PACKAGES="once:cmake ${PACKAGES}"
+

--- a/deal.II-toolchain/platforms/supported/debian9.platform
+++ b/deal.II-toolchain/platforms/supported/debian9.platform
@@ -7,7 +7,7 @@
 #   openmpi-bin openmpi-common libopenmpi-dev cmake subversion git \
 #   libblas-dev liblapack-dev libblas3 liblapack3 splint tcl tcl-dev \
 #   environment-modules libsuitesparse-dev libtool libboost-all-dev \
-#   qt4-dev-tools
+#   qt4-dev-tools libgmp-dev
 #
 # Then reboot and run candi again.
 ##


### PR DESCRIPTION
I added Debian 10 as supported platform and tested if it works. 

I also noticed that for the platforms CentOS 7 and Debian 9, the package for SymEngine (i.e. gmp-devel and libgmp-dev respectively) is missing. Therefore, I added these packages. 
Furthermore I guess that the package for SymEngine is also missing on other platforms.