### PR TITLE
trilinos: remove lgfortran flag

### DIFF
--- a/deal.II-toolchain/packages/trilinos.package
+++ b/deal.II-toolchain/packages/trilinos.package
@@ -140,8 +140,7 @@ fi
 CONFOPTS="${CONFOPTS} \
   -D CMAKE_CXX_FLAGS:STRING='-fPIC -g -O3' \
   -D CMAKE_C_FLAGS:STRING='-fPIC -g -O3' \
-  -D CMAKE_FORTRAN_FLAGS:STRING='-g -O3' \
-  -D Trilinos_EXTRA_LINK_FLAGS:STRING='-lgfortran'"
+  -D CMAKE_FORTRAN_FLAGS:STRING='-g -O3'"
 
 # Add ParMETIS, if present
 if [ ! -z "${PARMETIS_DIR}" ]; then


### PR DESCRIPTION
I have no idea what this flag is good for and it fails for me on M1 OSX
with this, because there is no gfortran library.