### PR TITLE
Ginkgo 1.4.0

### DIFF
--- a/deal.II-toolchain/packages/ginkgo.package
+++ b/deal.II-toolchain/packages/ginkgo.package
@@ -2,7 +2,7 @@
 ## GINKGO                                                                     ##
 ################################################################################
 
-VERSION=develop
+VERSION=v1.4.0
 NAME=ginkgo.git
 SOURCE=https://github.com/ginkgo-project/
 EXTRACTSTO=ginkgo-${VERSION}

--- a/deal.II-toolchain/packages/ginkgo.package
+++ b/deal.II-toolchain/packages/ginkgo.package
@@ -2,11 +2,32 @@
 ## GINKGO                                                                     ##
 ################################################################################
 
-VERSION=v1.4.0
-NAME=ginkgo.git
-SOURCE=https://github.com/ginkgo-project/
-EXTRACTSTO=ginkgo-${VERSION}
-PACKING=git
+# By default load the tarball.
+# To load the git repository define a variable CANDI_GINKGO_LOAD_TARBALL=OFF.
+if [ -z ${CANDI_GINKGO_LOAD_TARBALL} ]; then
+    CANDI_GINKGO_LOAD_TARBALL=ON
+fi
+
+if [ ${CANDI_GINKGO_LOAD_TARBALL} = ON ]; then
+    # download release tarball
+    VERSION=1.4.0
+    CHECKSUM=6dcadbd3e93f6ec58ef6cda5b980fbf51ea3c7c13e27952ef38804058ac93f08
+    CHECKSUM="${CHECKSUM} 10d244ce127cca3c735587d836c6308cfca0c855"
+    CHECKSUM="${CHECKSUM} d7ff9d564f8ca96b9ad33621821aff48"
+
+    NAME=v${VERSION}
+    SOURCE=https://github.com/ginkgo-project/ginkgo/archive/refs/tags/
+    EXTRACTSTO=ginkgo-${VERSION}
+    PACKING=.tar.gz
+else
+    # download git repository
+    VERSION=v1.4.0
+    NAME=ginkgo.git
+    SOURCE=https://github.com/ginkgo-project/
+    EXTRACTSTO=ginkgo-${VERSION}
+    PACKING=git
+fi
+unset CANDI_GINKGO_LOAD_TARBALL
 
 BUILDCHAIN=cmake
 


### PR DESCRIPTION
Ginkgo 1.4.0 is out so we can go from develop to the latest stable version. Previously it was only with develop possible to build the dealii+ginkgo interface correctly.