### PR TITLE
Adds platform AlmaLinux as replacement for CentOS 8

### DIFF
--- a/candi.sh
+++ b/candi.sh
@@ -634,6 +634,9 @@ guess_platform() {
         elif [ "${OS_ID}" == "centos" ]; then
             echo centos${OS_VERSION_ID}
 
+        elif [ "${OS_ID}" == "almalinux" ]; then
+            echo almalinux${OS_MAJOR_VERSION}
+
         elif [ "${OS_ID}" == "rhel" ]; then
             echo rhel${OS_MAJOR_VERSION}
 

--- a/deal.II-toolchain/platforms/supported/almalinux8.platform
+++ b/deal.II-toolchain/platforms/supported/almalinux8.platform
@@ -1,0 +1,36 @@
+# AlmaLinux 8
+
+# This build script assumes that you have several packages already
+# installed.
+#
+# > sudo dnf groupinstall "Development Tools"
+# > sudo dnf install git wget \
+#   gcc-c++ cmake \
+#   openmpi openmpi-devel \
+#   patch \
+#   libtool libtool-ltdl libtool-ltdl-devel \
+#   lua lua-devel \
+#   blas blas-devel lapack lapack-devel \
+#   gmp gmp-devel \
+#   doxygen graphviz graphviz-devel
+#
+# Please load the 'openmpi' compiler with
+#
+# > module load mpi/openmpi-x86_64
+#
+# and then set the compiler enviroment variables to
+#
+# > export CC=mpicc; export CXX=mpicxx; export FC=mpif90; export FF=mpif77
+#
+# before you continue!
+##
+
+# On RHEL 7 the candi installed parmetis 4.0.3 is not recognized correctly
+# for trilinos 12-10-1. We force to assume parmetis version 4.0.3.
+#TRILINOS_PARMETIS_CONFOPTS="\
+#    ${TRILINOS_PARMETIS_CONFOPTS} \
+#    -D HAVE_PARMETIS_VERSION_4_0_3:BOOL=ON"
+
+#
+# Define the additional packages for this platform.
+#PACKAGES="once:cmake ${PACKAGES}"


### PR DESCRIPTION
CentOS 8 will have its end of life by the end of 2021. One can switch to AlmaLinux 8 as a replacement.