### PR TITLE
Add arch native flags to p4est and trilinos if native optimazations is on

### DIFF
--- a/deal.II-toolchain/packages/p4est.package
+++ b/deal.II-toolchain/packages/p4est.package
@@ -39,7 +39,11 @@ package_specific_setup() {
     fi
 
     if test -z "${CFLAGS}" -a -z "${P4EST_CFLAGS_FAST}"; then
-        export CFLAGS_FAST="-O2"
+         if [ ${NATIVE_OPTIMIZATIONS} = OFF ]; then
+             export CFLAGS_FAST="-O2"
+         else
+             export CFLAGS_FAST="-O2 -march=native"
+         fi
     else
         export CFLAGS_FAST="${CFLAGS} ${P4EST_CFLAGS_FAST}"
     fi

--- a/deal.II-toolchain/packages/trilinos.package
+++ b/deal.II-toolchain/packages/trilinos.package
@@ -153,10 +153,17 @@ if [ ! -z "${FC}" ]; then
       -D CMAKE_Fortran_COMPILER=${FC}"
 fi
 
+if [ ${NATIVE_OPTIMIZATIONS} = OFF ]; then
 CONFOPTS="${CONFOPTS} \
   -D CMAKE_CXX_FLAGS:STRING='-fPIC -g -O3' \
   -D CMAKE_C_FLAGS:STRING='-fPIC -g -O3' \
   -D CMAKE_FORTRAN_FLAGS:STRING='-g -O3'"
+else
+CONFOPTS="${CONFOPTS} \
+  -D CMAKE_CXX_FLAGS:STRING='-fPIC -g -O3 -march=native' \
+  -D CMAKE_C_FLAGS:STRING='-fPIC -g -O3 -march=native' \
+  -D CMAKE_FORTRAN_FLAGS:STRING='-g -O3 -march=native'"
+fi
 
 # Add ParMETIS, if present
 if [ ! -z "${PARMETIS_DIR}" ]; then


### PR DESCRIPTION
I wasn't sure if there was any reason why native optimizations wasn't turned on for anything else then deal.ii and pestc, so I tired it with trilinos, p4est and openblas. It seems to work for the first two, but I had issues setting it correctly for openblas. 

If there is any reason why this is not safe to do for these two packages, please let me know.