### PR TITLE
Version independent comment

### DIFF
--- a/candi.cfg
+++ b/candi.cfg
@@ -90,7 +90,7 @@ PACKAGES="${PACKAGES} dealii"
 
 #########################################################################
 
-# Install the following deal.II version (choose master v9.3.0 ...)
+# Install the following deal.II version (choose master, v9.3.0, v9.2.0, ...)
 DEAL_II_VERSION=master
 
 #########################################################################


### PR DESCRIPTION
As new version of dealii are release this comment would have to be adapted every time. Now it is independent.