### PR TITLE
unset CMAKE_GENERATOR

### DIFF
--- a/candi.sh
+++ b/candi.sh
@@ -37,6 +37,9 @@ fi
 # Start global timer
 TIC_GLOBAL="$(${DATE_CMD} +%s)"
 
+# unset CMAKE_GENERATOR because we assume the default (make) to be used
+unset CMAKE_GENERATOR
+
 ################################################################################
 # Parse command line input parameters
 PREFIX=~/dealii-candi


### PR DESCRIPTION
One can set the CMAKE_GENERATOR to set the default generator when cmake
is executed (I have set it to Ninja). This of course confuses candi, as
no makefiles will be generated.