### PR TITLE
opencascade: fix isfinite error

### DIFF
--- a/deal.II-toolchain/packages/opencascade.package
+++ b/deal.II-toolchain/packages/opencascade.package
@@ -61,6 +61,8 @@ package_specific_patch () {
     cd ${UNPACK_PATH}/${EXTRACTSTO}
     cecho ${WARN} "applying patch for missing xlocale.h for glibc v2.26 and above"
     patch -p0 --forward < ${ORIG_DIR}/${PROJECT}/patches/oce-xlocale.patch || true
+    cecho ${WARN} "applying patch for isfinite"
+    patch -p0 --forward < ${ORIG_DIR}/${PROJECT}/patches/oce-isfinite.patch
 }
 
 package_specific_register () {

--- a/deal.II-toolchain/patches/oce-isfinite.patch
+++ b/deal.II-toolchain/patches/oce-isfinite.patch
@@ -1,0 +1,11 @@
+--- src/OSD/OSD.cxx     2022-02-11 14:34:21.726133403 -0500
++++ src.patched/OSD/OSD.cxx     2022-02-11 14:33:27.025817808 -0500
+@@ -18,7 +18,7 @@
+ #include <math.h>
+ #ifdef WNT
+ # define finite _finite
+-#elif defined(isfinite)
++#else
+ # define finite isfinite
+ #endif
+


### PR DESCRIPTION
On M1 opencascade fails to compile, fix by adding a patch.

part of #196