### PR TITLE
Do not export gmsh path

### DIFF
--- a/deal.II-toolchain/packages/gmsh.package
+++ b/deal.II-toolchain/packages/gmsh.package
@@ -60,7 +60,6 @@ CONFOPTS="\
 
 package_specific_register () {
     export GMSH_DIR=${INSTALL_PATH}
-    export PATH=${INSTALL_PATH}/bin:$PATH
 }
 
 package_specific_conf () {
@@ -69,6 +68,5 @@ package_specific_conf () {
     rm -f $CONFIG_FILE
     echo "
 export GMSH_DIR=${INSTALL_PATH}
-export PATH=${INSTALL_PATH}/bin:\$PATH
 " >> $CONFIG_FILE
 }


### PR DESCRIPTION
It is not necessary to export the ``PATH`` for the gmsh package. Just tested on the GitHub runners: https://github.com/gfcas/candi/actions/runs/1840955434