### PR TITLE
native optimizations: enable -O3

### DIFF
--- a/deal.II-toolchain/packages/dealii.package
+++ b/deal.II-toolchain/packages/dealii.package
@@ -38,7 +38,8 @@ fi
 # Choice of whether native compiler optimizations should be enabled
 if [ ${NATIVE_OPTIMIZATIONS} = ON ]; then
     CONFOPTS="${CONFOPTS} \
-      -D CMAKE_CXX_FLAGS='-march=native'"
+      -D CMAKE_CXX_FLAGS='-march=native' \
+      -D CMAKE_CXX_FLAGS_RELEASE='-O3'"
 fi
 
 if [ ${USE_DEAL_II_CMAKE_MPI_COMPILER} = ON ]; then


### PR DESCRIPTION
We found out that -O3 makes a measurable difference in matrix-free
performance for recent gcc versions. Enable this when the user requests
native optimizations.