### PR TITLE
ADOL-C: Add default options that are most useful/defensive for users

### DIFF
--- a/deal.II-toolchain/packages/adolc.package
+++ b/deal.II-toolchain/packages/adolc.package
@@ -34,7 +34,7 @@ BUILDCHAIN=autotools
 BUILDDIR=${BUILD_PATH}/adolc-${VERSION}
 INSTALL_PATH=${INSTALL_PATH}/adolc-${VERSION}
 
-CONFOPTS="--enable-atrig-erf --with-boost=no"
+CONFOPTS="--enable-advanced-branching --enable-atrig-erf --enable-traceless_refcounting --enable-stdczero --with-boost=no"
 
 package_specific_register () {
     export ADOLC_DIR=${INSTALL_PATH}


### PR DESCRIPTION
These are the most sane set of options for ADOL-C that I know of. They allow us to make sure that the user can rely on the deal.II AD drivers to catch errors (`traceless_refcounting`). They also help permit the most natural coding style in terms of variable initialisation (`stdczero`) and allow traced/taped numbers to be used most robustly in functions with complex branch conditions (`advanced-branching`).