### PR TITLE
Fix path to installed CMake files.

### DIFF
--- a/deal.II-toolchain/packages/cmake.package
+++ b/deal.II-toolchain/packages/cmake.package
@@ -45,7 +45,7 @@ fi
 
 package_specific_register () {
     export PATH=${INSTALL_PATH}/bin:${PATH}
-    export CMAKE_ROOT=${INSTALL_PATH}/share/${MAJOR}
+    export CMAKE_ROOT=${INSTALL_PATH}/share/cmake-${MAJOR}
 }
 
 package_specific_conf () {
@@ -54,6 +54,6 @@ package_specific_conf () {
     rm -f $CONFIG_FILE
     echo "
 export PATH=${INSTALL_PATH}/bin:\${PATH}
-export CMAKE_ROOT=${INSTALL_PATH}/share/${MAJOR}
+export CMAKE_ROOT=${INSTALL_PATH}/share/cmake-${MAJOR}
 " >> $CONFIG_FILE
 }


### PR DESCRIPTION
Same as

https://github.com/IBAMR/autoibamr/pull/79

but for candi.

autoibamr is like candi but for ibamr instead of deal.II - candi works well enough that I just copied and pasted it and added and removed dependencies. Hence bug reports for autoibamr sometimes apply here too.