### PR TITLE
fix bug on metis installation when USE_64_BIT_INDICES=ON

### DIFF
--- a/deal.II-toolchain/packages/parmetis.package
+++ b/deal.II-toolchain/packages/parmetis.package
@@ -17,16 +17,7 @@ if [ ${USE_64_BIT_INDICES} = ON ]; then
   modifications on other architectures.
  --------------------------------------------------------------------------*/
 -#define IDXTYPEWIDTH 32
-+#define IDXTYPEWIDTH 64
-
-
- /*--------------------------------------------------------------------------
-@@ -40,7 +40,7 @@
-    32 : single precission floating point (float)
-    64 : double precission floating point (double)
- --------------------------------------------------------------------------*/
--#define REALTYPEWIDTH 32
-+#define REALTYPEWIDTH 64"  | tee -a ${ORIG_DIR}/${PROJECT}/patches/parmetis-4.0.3-build.patch
++#define IDXTYPEWIDTH 64"  | tee -a ${ORIG_DIR}/${PROJECT}/patches/parmetis-4.0.3-build.patch
 fi
 
 package_specific_build() {

--- a/deal.II-toolchain/packages/parmetis.package
+++ b/deal.II-toolchain/packages/parmetis.package
@@ -7,19 +7,6 @@ BUILDCHAIN=custom
 
 INSTALL_PATH=${INSTALL_PATH}/${NAME}
 
-if [ ${USE_64_BIT_INDICES} = ON ]; then
-
-    echo "
---- metis/include/metis.h	2013-03-30 16:24:50.000000000 +0000
-+++ metis/include/metis.h	2022-11-27 16:14:07.863359070 +0000
-@@ -30,7 +30,7 @@
-  GCC does provides these definitions in stdint.h, but it may require some
-  modifications on other architectures.
- --------------------------------------------------------------------------*/
--#define IDXTYPEWIDTH 32
-+#define IDXTYPEWIDTH 64"  | tee -a ${ORIG_DIR}/${PROJECT}/patches/parmetis-4.0.3-build.patch
-fi
-
 package_specific_build() {
     cp -rf ${UNPACK_PATH}/${EXTRACTSTO}/* .
     
@@ -54,6 +41,12 @@ package_specific_patch () {
             cd ${UNPACK_PATH}/${EXTRACTSTO}
             cecho ${WARN} "applying patch for building METIS shared libraries"
             patch -p0 --forward < ${ORIG_DIR}/${PROJECT}/patches/parmetis-4.0.3-build.patch || true
+
+            if [ ${USE_64_BIT_INDICES} = ON ]; then
+            cd ${UNPACK_PATH}/${EXTRACTSTO}
+            cecho ${WARN} "applying patch for 64bit ParMETIS"
+            patch -p0 --forward < ${ORIG_DIR}/${PROJECT}/patches/parmetis-4.0.3-64bit.patch || true
+            fi
         fi
     fi
 }

--- a/deal.II-toolchain/packages/parmetis.package
+++ b/deal.II-toolchain/packages/parmetis.package
@@ -7,6 +7,28 @@ BUILDCHAIN=custom
 
 INSTALL_PATH=${INSTALL_PATH}/${NAME}
 
+if [ ${USE_64_BIT_INDICES} = ON ]; then
+
+    echo "
+--- metis/include/metis.h	2013-03-30 16:24:50.000000000 +0000
++++ metis/include/metis.h	2022-11-27 16:14:07.863359070 +0000
+@@ -30,7 +30,7 @@
+  GCC does provides these definitions in stdint.h, but it may require some
+  modifications on other architectures.
+ --------------------------------------------------------------------------*/
+-#define IDXTYPEWIDTH 32
++#define IDXTYPEWIDTH 64
+
+
+ /*--------------------------------------------------------------------------
+@@ -40,7 +40,7 @@
+    32 : single precission floating point (float)
+    64 : double precission floating point (double)
+ --------------------------------------------------------------------------*/
+-#define REALTYPEWIDTH 32
++#define REALTYPEWIDTH 64"  | tee -a ${ORIG_DIR}/${PROJECT}/patches/parmetis-4.0.3-build.patch
+fi
+
 package_specific_build() {
     cp -rf ${UNPACK_PATH}/${EXTRACTSTO}/* .
     

--- a/deal.II-toolchain/patches/parmetis-4.0.3-64bit.patch
+++ b/deal.II-toolchain/patches/parmetis-4.0.3-64bit.patch
@@ -1,0 +1,8 @@
+--- metis/include/metis.h	2013-03-30 16:24:50.000000000 +0000
++++ metis/include/metis.h	2022-11-27 16:14:07.863359070 +0000
+@@ -30,7 +30,7 @@
+  GCC does provides these definitions in stdint.h, but it may require some
+  modifications on other architectures.
+ --------------------------------------------------------------------------*/
+-#define IDXTYPEWIDTH 32
++#define IDXTYPEWIDTH 64


### PR DESCRIPTION
# Description of the problem

- When "USE_64_BIT_INDICES=ON" and install both ParMETIS & PETSc, The installation will be stopped with an error as shown below from the PETSc:
```
==============
Configuring PETSc to compile on your system                            
==============

==============
UNABLE to CONFIGURE with GIVEN OPTIONS    (see configure.log for details):
==============

Metis specified is incompatible!

--with-64-bit-indices option requires a metis build with IDXTYPEWIDTH=64.
Suggest using --download-metis for a compatible metis
```
- After checking, it is the Line33 & Line 43 of "*/parmetis-4.0.3/metis/include/metis.h" that still keep
```
#define IDXTYPEWIDTH 32
```
& 
```
#define REALTYPEWIDTH 32
```

# Description of the solution

- Add an "if" block in the "parmetis.package". 
- If "USE_64_BIT_INDICES=ON", add extra pieces of codes in "${ORIG_DIR}/${PROJECT}/patches/parmetis-4.0.3-build.patch" to modify the IDXTYPEWIDTH & REALTYPEWIDTH.

# How Has This Been Tested?
- Tested the modified candi on Ubuntu desktop.

