### PR TITLE
fix issue on undefined reference to gotoblas

### DIFF
--- a/deal.II-toolchain/packages/openblas.package
+++ b/deal.II-toolchain/packages/openblas.package
@@ -23,7 +23,7 @@ package_specific_build () {
     cd ${BUILDDIR}
     cp -rf ${UNPACK_PATH}/${EXTRACTSTO}/* .
 
-    make -j ${JOBS} PREFIX=${INSTALL_PATH}
+    make -j ${JOBS} PREFIX=${INSTALL_PATH} DYNAMIC_ARCH=1
     quit_if_fail "make failed"
 
     make install -j ${JOBS} PREFIX=${INSTALL_PATH}


### PR DESCRIPTION
# Description of the problem
- When installing deal.ii with OpenBLAS, the installation will be stopped with an error as shown below from deal.ii:
```
[ 75%] Linking CXX executable ../bin/step-78.release
/usr/bin/ld: /lib/x86_64-linux-gnu/libblas.so.3: undefined reference to `gotoblas'
collect2: error: ld returned 1 exit status
make[2]: *** [examples/CMakeFiles/step-9.release.dir/build.make:258: bin/step-9.release] Error 1
make[1]: *** [CMakeFiles/Makefile2:3939: examples/CMakeFiles/step-9.release.dir/all] Error 2
```

# Description of the solution
- According to OpenBLAS PR#3282 (https://github.com/xianyi/OpenBLAS/issues/3282), building OpenBLAS with 'DYNAMIC_ARCH=1' will fix the issue.

# How Has This Been Tested?
- Tested the modified candi on Ubuntu desktop.