### PR TITLE
Enable the choice of a specific CMAKE version

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ see [deal.II-toolchain/platforms](deal.II-toolchain/platforms).
 With this option you skip the user interaction. This might be useful if you
 submit the installation to the queueing system of a cluster.
 
+#### Specific cmake version: ``[--cmake_path=<path>]``
+```bash
+  ./candi.sh --cmake_path="/path/to/install/dir"
+```
+With this option you can choose a specific cmake installation. This might be
+necessary if a package requires a minimum cmake version that is not satisfied
+by the version provided by your operating system.
 
 ### Configuration file options
 

--- a/candi.sh
+++ b/candi.sh
@@ -46,6 +46,7 @@ PREFIX=~/dealii-candi
 JOBS=1
 CMD_PACKAGES=""
 USER_INTERACTION=ON
+CMAKE=cmake
 
 while [ -n "$1" ]; do
     param="$1"
@@ -61,6 +62,7 @@ while [ -n "$1" ]; do
 	    echo "  --platform=<platform>       force usage of a particular platform file"
 	    echo "  --packages=\"pkg1 pkg2\"      install the given list of packages instead of the default set in candi.cfg"
 	    echo "  -y, --yes, --assume-yes     automatic yes to prompts"
+        echo "  --cmake_path=<path_to_desired_cmake>  use user defined cmake-version"
 	    echo ""
 	    echo "The configuration including the choice of packages to install is stored in candi.cfg, see README.md for more information."
 	    exit 0
@@ -108,6 +110,12 @@ while [ -n "$1" ]; do
         # Assume yes to prompts
         -y|--yes|--assume-yes)
             USER_INTERACTION=OFF
+        ;;
+
+        #####################################
+        # Specific cmake version
+        --cmake_path=*)
+            CMAKE="${param#*=}"
         ;;
 
 	*)
@@ -533,7 +541,7 @@ package_build() {
     elif [ ${BUILDCHAIN} = "cmake" ]; then
         rm -f ${BUILDDIR}/CMakeCache.txt
         rm -rf ${BUILDDIR}/CMakeFiles
-        echo cmake ${CONFOPTS} -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH} ${UNPACK_PATH}/${EXTRACTSTO} >>candi_configure
+        echo ${CMAKE} ${CONFOPTS} -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH} ${UNPACK_PATH}/${EXTRACTSTO} >>candi_configure
         for target in "${TARGETS[@]}"; do
             echo make ${MAKEOPTS} -j ${JOBS} $target >>candi_build
         done


### PR DESCRIPTION
While using candi, I ran into the problem that the CMAKE version being shipped with the OS (Ubuntu 20.04, cmake: 3.16.3) is not new enough to compile Trilinos (I think it requires cmake > 3.17 ). Thus, I added the possibility to flexibly choose another installation of CMAKE by providing the corresponding path, which worked fine on my workstation.

As I found this pretty helpful, I decided to push this to check whether you share my opinion.
