### PR TITLE
Correctly unset PETSc environment variables.

### DIFF
--- a/candi.sh
+++ b/candi.sh
@@ -161,6 +161,11 @@ INFO="\033[1;34m"
 BOLD="\033[1m"
 
 ################################################################################
+# Ensure that no PETSc environment variables are set.
+unset PETSC_DIR
+unset PETSC_ARCH
+
+################################################################################
 # Define candi helper functions
 
 prettify_dir() {

--- a/deal.II-toolchain/packages/petsc.package
+++ b/deal.II-toolchain/packages/petsc.package
@@ -120,9 +120,13 @@ package_specific_setup () {
     cd ${BUILDDIR}
     cp -rf ${UNPACK_PATH}/${EXTRACTSTO}/* .
 
-    # make sure no other invalid PETSC_DIR is set:
+    # Make sure we don't pick up any environment copies of PETSc variables. This
+    # duplicates the same unset commands in candi.sh to ensure that, should this
+    # function run as a shell script (i.e., not with the source command), they
+    # are not reset by .bash_profile or some other shell initialization script.
     unset PETSC_DIR
-    
+    unset PETSC_ARCH
+
     ${PYTHON_INTERPRETER} ./configure --prefix=${INSTALL_PATH} ${CONFOPTS} COPTFLAGS="${OPTFLAGS}" CXXOPTFLAGS="${OPTFLAGS}" FOPTFLAGS="${OPTFLAGS}"
     quit_if_fail "petsc ./configure failed"
     


### PR DESCRIPTION
Same as https://github.com/IBAMR/autoibamr/pull/120 but for candi. If a user has `PETSC_ARCH` set (i.e., by some system-wide PETSc install) then we want to unset it. Presently we only unset `PETSC_DIR`.

I didn't verify that this bug exists with candi too but I'm pretty sure it does since we run
```cmake
set(PETSC_DIR "" CACHE PATH "An optional hint to a PETSc directory")
set(PETSC_ARCH "" CACHE STRING "An optional hint to a PETSc arch")
set_if_empty(PETSC_DIR "$ENV{PETSC_DIR}")
set_if_empty(PETSC_ARCH "$ENV{PETSC_ARCH}")
```
in `FindPETSc.cmake` - i.e., we will, in this circumstance, set `PETSC_ARCH` to an invalid value.