### PR TITLE
enable Trilinos NOX

### DIFF
--- a/deal.II-toolchain/packages/trilinos.package
+++ b/deal.II-toolchain/packages/trilinos.package
@@ -248,6 +248,7 @@ CONFOPTS="\
   -D   Teuchos_ENABLE_FLOAT:BOOL=ON \
   -D Trilinos_ENABLE_MueLu:BOOL=ON \
   -D Trilinos_ENABLE_ML:BOOL=ON \
+  -D Trilinos_ENABLE_NOX:BOOL=ON \
   -D Trilinos_ENABLE_ROL:BOOL=ON \
   -D Trilinos_ENABLE_Zoltan:BOOL=ON \
   -D Trilinos_ENABLE_Stratimikos:BOOL=ON \


### PR DESCRIPTION
explicitly enable NOX (even though it is active by default)

fixes #351