### PR TITLE
master branch: install deal.II 9.5.1 by default

### DIFF
--- a/candi.cfg
+++ b/candi.cfg
@@ -94,7 +94,7 @@ PACKAGES="${PACKAGES} dealii"
 #########################################################################
 
 # Install the following deal.II version (choose master, v9.3.0, v9.2.0, ...)
-DEAL_II_VERSION=master
+DEAL_II_VERSION=v9.5.1
 
 #########################################################################
 


### PR DESCRIPTION
We will switch the default branch of candi to master to simplify testing and development