### PR TITLE
Use Trilinos 16.1.0 to fix Kokkos compilation error

### DIFF
--- a/deal.II-toolchain/packages/trilinos.package
+++ b/deal.II-toolchain/packages/trilinos.package
@@ -23,7 +23,13 @@ if [ ${TRILINOS_MAJOR_VERSION} = "DEV" ];then
     SOURCE=https://github.com/trilinos/
 elif [ ${TRILINOS_MAJOR_VERSION} = "16" ]; then
 
+    # Trilinos 16.1.0 includes Kokkos 4.5.1 update that
+    # fixes Trilinos "no member named 'sort_option' in 'SPADDHandle'"
+    # compilation error (see issue:
+    # https://github.com/trilinos/Trilinos/issues/13570)
     VERSION=16-1-0;CHECKSUM=d58ba4bcbcde701ee3a3e2e7cc27b6ca
+
+    # VERSION=16-0-0;CHECKSUM=e6d83f7980800a3aad1b7cab6b901fd5
 
     SOURCE=https://github.com/trilinos/Trilinos/archive/
     NAME=trilinos-release-${VERSION}

--- a/deal.II-toolchain/packages/trilinos.package
+++ b/deal.II-toolchain/packages/trilinos.package
@@ -29,8 +29,6 @@ elif [ ${TRILINOS_MAJOR_VERSION} = "16" ]; then
     # https://github.com/trilinos/Trilinos/issues/13570)
     VERSION=16-1-0;CHECKSUM=d58ba4bcbcde701ee3a3e2e7cc27b6ca
 
-    # VERSION=16-0-0;CHECKSUM=e6d83f7980800a3aad1b7cab6b901fd5
-
     SOURCE=https://github.com/trilinos/Trilinos/archive/
     NAME=trilinos-release-${VERSION}
     EXTRACTSTO=Trilinos-trilinos-release-${VERSION}

--- a/deal.II-toolchain/packages/trilinos.package
+++ b/deal.II-toolchain/packages/trilinos.package
@@ -29,6 +29,8 @@ elif [ ${TRILINOS_MAJOR_VERSION} = "16" ]; then
     # https://github.com/trilinos/Trilinos/issues/13570)
     VERSION=16-1-0;CHECKSUM=d58ba4bcbcde701ee3a3e2e7cc27b6ca
 
+    # VERSION=16-0-0;CHECKSUM=e6d83f7980800a3aad1b7cab6b901fd5
+
     SOURCE=https://github.com/trilinos/Trilinos/archive/
     NAME=trilinos-release-${VERSION}
     EXTRACTSTO=Trilinos-trilinos-release-${VERSION}

--- a/deal.II-toolchain/packages/trilinos.package
+++ b/deal.II-toolchain/packages/trilinos.package
@@ -23,7 +23,7 @@ if [ ${TRILINOS_MAJOR_VERSION} = "DEV" ];then
     SOURCE=https://github.com/trilinos/
 elif [ ${TRILINOS_MAJOR_VERSION} = "16" ]; then
 
-    VERSION=16-0-0;CHECKSUM=e6d83f7980800a3aad1b7cab6b901fd5
+    VERSION=16-1-0;CHECKSUM=d58ba4bcbcde701ee3a3e2e7cc27b6ca
 
     SOURCE=https://github.com/trilinos/Trilinos/archive/
     NAME=trilinos-release-${VERSION}


### PR DESCRIPTION
A known bug in Kokkos causes candi to crash during the Trilinos compilation with `error: no member named 'sort_option' in 'SPADDHandle'`. This bug was fixed in Kokkos 4.5.1, which is now bundled with Trilinos [16.1.0](https://github.com/trilinos/Trilinos/releases/tag/trilinos-release-16-1-0). See Trilinos issue [#13570](https://github.com/trilinos/Trilinos/issues/13570).

Updating the Trilinos version and checksum from 16.0.0 to 16.1.0 in `deal.II-toolchain/packages/trilinos.package` fixes the issue. Candi now compiles Trilinos without crashing.

Tested on Apple M1 (arm64-apple-darwin24.4.0) with macOS 15.4.1 using mpicc (Apple clang version 17.0.0)