### PR TITLE
Update macos.platform and docs

### DIFF
--- a/candi.sh
+++ b/candi.sh
@@ -536,6 +536,32 @@ package_build() {
         done
 
     elif [ ${BUILDCHAIN} = "cmake" ]; then
+        # Check for cmake availability before proceeding
+        if command -v brew &>/dev/null; then
+            # Look for homebrew cmake and exit if not installed
+            if brew list "cmake" &>/dev/null; then
+                cecho ${INFO} "Found 'cmake' installed via Homebrew ..."
+            elif command -v "cmake" &>/dev/null; then
+                cecho ${INFO} "Found 'cmake' installed locally ..."
+            else
+                cecho ${BAD} "candi: Internal error: cmake not found!"
+                cecho ${BAD} "cmake is required to build ${NAME}."
+                cecho ${BAD} "The easiest way to get cmake on your macOS system is to install it via Homebrew."
+                cecho ${BAD} "Install cmake using: 'brew install cmake'"
+                cecho ${BAD} "and then run candi again."
+                exit 1
+            fi
+        else
+            # Look for cmake locally and exit if not installed
+            if command -v "cmake" &>/dev/null; then
+                cecho ${INFO} "Found 'cmake' installed locally ..."
+            else
+                cecho ${BAD} "candi: Internal error: cmake not found!"
+                cecho ${BAD} "cmake is required to build ${NAME}."
+                cecho ${BAD} "Install cmake and run candi again."
+                exit 1
+            fi
+        fi
         rm -f ${BUILDDIR}/CMakeCache.txt
         rm -rf ${BUILDDIR}/CMakeFiles
         echo cmake ${CONFOPTS} -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH} ${UNPACK_PATH}/${EXTRACTSTO} >>candi_configure

--- a/deal.II-toolchain/packages/dealii.package
+++ b/deal.II-toolchain/packages/dealii.package
@@ -107,6 +107,44 @@ if [ ! -z "${DEAL_CHERRYPICKCOMMITS}" ]; then
 fi
 
 ################################################################################
+# Handle Homebrew HDF5 conflicts on macOS with robust cleanup
+if [ "$(machine)" = "arm64e" ]; then
+    HDF5_WAS_UNLINKED_BY_DEALII=false
+
+    # Cleanup function for HDF5
+    cleanup_hdf5() {
+        if [ "$HDF5_WAS_UNLINKED_BY_DEALII" = true ]; then
+            cecho ${INFO} "deal.II: Restoring Homebrew HDF5..."
+            if brew link hdf5 2>/dev/null; then
+                cecho ${GOOD} "deal.II: Homebrew HDF5 successfully restored"
+            else
+                cecho ${BAD} "deal.II: Warning - Failed to restore Homebrew HDF5"
+                cecho ${BAD} "deal.II: You may need to run: brew link hdf5"
+            fi
+        fi
+    }
+
+    # Set up trap handlers (only if not already set)
+    if [ -z "$HDF5_TRAP_SET" ]; then
+        trap cleanup_hdf5 EXIT INT TERM HUP
+        export HDF5_TRAP_SET=1
+    fi
+
+    # Check if we're on macOS and have Homebrew HDF5
+    if command -v brew &>/dev/null && brew list hdf5 &>/dev/null 2>&1; then
+        cecho ${INFO} "deal.II: Detected Homebrew HDF5, temporarily unlinking to avoid conflicts"
+
+        if brew unlink hdf5; then
+            HDF5_WAS_UNLINKED_BY_DEALII=true
+            cecho ${GOOD} "deal.II: Homebrew HDF5 unlinked successfully"
+        else
+            cecho ${BAD} "deal.II: Failed to unlink Homebrew HDF5"
+            exit 1
+        fi
+    fi
+fi
+
+################################################################################
 # Add additional packages, if present
 
 ########################################

--- a/deal.II-toolchain/platforms/supported/macos.platform
+++ b/deal.II-toolchain/platforms/supported/macos.platform
@@ -1,46 +1,50 @@
 # macOS
 #
 # Detailed Installation Notes:
-# - Install Xcode from AppStore, open it and accept the license.
 # - Open Terminal, and install Xcode command line tools via
 # $  xcode-select --install
-# and then run
-# $  xcodebuild -license
-# and accept the license.
 #
-# Make sure you can run
+# - Check if Xcode command line tools are installed by running
 # $ clang -v
-# (it might trigger an installation the first time you run it).
 #
-# - Install Homebrew in a Terminal via
+# - Install Homebrew via
 # $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 #
-# - Install the following via Homebrew
-# $  brew install cmake gcc@11 openmpi
+# - Install CMake and Open MPI via Homebrew
+# $  brew install cmake open-mpi
+#
+# - macOS users with Intel machines also need GCC
+# $  brew install gcc@13
 #
 # - Export compiler environment:
+#
+# ------------------- macOS arm64 -------------------
 #
 # If you are running an ARM based macOS device (M1, M2, etc.), we strongly recommend
 # using the clang compiler, which is the default. You can check so by running
 # $ mpicxx -v
 # If it reports "clang", you are good to go.
 #
+# ARM support is still experimental and not all packages and options work
+# without problems. It might be easiest to start by only enabling the packages
+# you care about.
+#
+# ------------------- macOS Intel -------------------
+#
 # If you are not running on an ARM device (traditional Intel based laptops), we
 # strongly recommend using gcc instead of clang. This can be achieved by running
 #
 # $ export CC=mpicc; export CXX=mpicxx; export FC=mpifort; export FF=mpifort; \
-# OMPI_CC=gcc-11; export OMPI_CXX=g++-11; export OMPI_FC=gfortran-11
+# OMPI_CC=gcc-13; export OMPI_CXX=g++-13; export OMPI_FC=gfortran-13
 #
-# Finally, ARM support is still experimental and not all packages and options work
-# without problems. It might be easiest to start by only enabling the packages
-# you care about.
+# ---------------------------------------------------
 #
-# If you are missing any steps, abort this installation now, do the changes and then
+# - If you are missing any steps, abort this installation now, do the changes and then
 # run candi again!
 #
 # You might also want to consult:
-# - https://github.com/dealii/dealii/wiki/MacOSX
-# - https://github.com/dealii/dealii/wiki/Apple-ARM-M1-OSX
+# - https://github.com/dealii/dealii/wiki/MacOSX (for Intel Macs)
+# - https://github.com/dealii/dealii/wiki/Apple-ARM-M1-OSX (for M1–M4 Macs)
 #
 # If you encounter runtime problems with missing *.dylib libraries,
 # you may change the security policy for developments. To do so,
@@ -48,7 +52,10 @@
 ##
 
 if [ "$(machine)" = "arm64e" ]; then
-  cecho ${INFO} "MacOS on arm64 detected!"
+  # Remove cmake from the PACKAGES list because the preferred install method
+  # for cmake on macOS is via Homebrew (so cmake will always be in the path)
+  PACKAGES="${PACKAGES//once:cmake/}"
+  PACKAGES="${PACKAGES//cmake/}"
 
   # Trilinos will link with netcdf and indirectly hdf5, but linking fails. Just
   # disable this for now.


### PR DESCRIPTION
This PR adds some basic checks to the default macOS toolchain:

1. checks if cmake is installed locally or via homebrew. If not, exit candi with a hint.
2. checks for incompatible (non-mpi enabled) hdf5 installed via homebrew. If hdf5 is installed via homebrew, exit candi with a hint.
3. uses Trilinos version 16.1 by default to avoid compilations errors on macOS arm64 stemming from a known Kokkos bug #401