### PR TITLE
Fix MKL-related floating-point configuration conflicts in Trilinos build

### DIFF
--- a/deal.II-toolchain/packages/trilinos.package
+++ b/deal.II-toolchain/packages/trilinos.package
@@ -173,6 +173,7 @@ if [ ${MKL} = ON ]; then
     CONFOPTS="${CONFOPTS} \
       -D BLAS_LIBRARY_NAMES:STRING='mkl_core;mkl_sequential' \
       -D Tpetra_INST_FLOAT:BOOL=OFF \
+      -D Trilinos_ENABLE_FLOAT:BOOL=OFF \
       -D Tpetra_INST_COMPLEX_FLOAT:BOOL=OFF \
       -D LAPACK_LIBRARY_NAMES:STRING=mkl_intel_lp64"
 else
@@ -183,6 +184,8 @@ else
           -D TPL_BLAS_LIBRARIES:STRING=${BLAS_LIB} \
           -D TPL_LAPACK_LIBRARIES:STRING=${BLAS_LIB}"
     fi
+    CONFOPTS="${CONFOPTS} \
+        -D Trilinos_ENABLE_FLOAT:BOOL=ON"
 fi
 
 # Set compilers & compiler options


### PR DESCRIPTION
I've made a fix to separate the `Trilinos_ENABLE_FLOAT` ON/OFF logic based on MKL usage to avoid compilation conflicts. Specifically, floating-point instantiations are disabled when MKL is enabled, and enabled otherwise.

However, I'm not sure if this fix alone is sufficient or appropriate as a PR. In my experience, the issue only occurs with Intel MPI + MKL, while OpenMPI + MKL works fine without disabling floating-point support.

Would it be better to add an `MPI type` check in the configuration to selectively apply this logic only when Intel MPI is used? I'd appreciate any advice or feedback on whether this is necessary or recommended.