### PR TITLE
Trilinos: disable SEACAS by default

### DIFF
--- a/candi.cfg
+++ b/candi.cfg
@@ -106,6 +106,9 @@ TRILINOS_MAJOR_VERSION=AUTO
 # Teuchos and Tpetra. This takes a long time to compile and requires a
 # lot of RAM. It is also likely not something you will need.
 TRILINOS_WITH_COMPLEX=OFF
+# If enabled, configure Trilinos with SEACAS TPL enabled, this
+# enables exodusII file format but requires pnetcdf:
+TRILINOS_WITH_SEACAS=OFF
 
 #########################################################################
 


### PR DESCRIPTION
It looks like Trilinos 16 requires pnetcdf but we only have netcdf, so it doesn't work.