### PR TITLE
Fix disabling gtest for newer trilinos versions (>=17)

### DIFF
--- a/deal.II-toolchain/packages/trilinos.package
+++ b/deal.II-toolchain/packages/trilinos.package
@@ -265,6 +265,16 @@ if [ ${TRILINOS_WITH_SEACAS} = ON ] && [ ! -z "${NETCDF_DIR}" ]; then
       -D Netcdf_INCLUDE_DIRS=${NETCDF_DIR}/include/"
 fi
 
+if [ ${TRILINOS_MAJOR_VERSION} = "DEV" -o ${TRILINOS_MAJOR_VERSION} > "16" ]; then
+    CONFOPTS="\
+    -D Trilinos_ENABLE_gtest:BOOL=OFF \
+    ${CONFOPTS}"
+else
+    CONFOPTS="\
+    -D Trilinos_ENABLE_Gtest:BOOL=OFF \
+    ${CONFOPTS}"
+fi
+
 #########################################################################
 # General Trilinos configuration
 
@@ -274,7 +284,6 @@ CONFOPTS="\
   -D TPL_ENABLE_TBB:BOOL=OFF \
   -D Trilinos_ENABLE_EXAMPLES:BOOL=OFF \
   -D Trilinos_ENABLE_TESTS:BOOL=OFF \
-  -D Trilinos_ENABLE_Gtest:BOOL=OFF \
   -D Trilinos_VERBOSE_CONFIGURE:BOOL=OFF \
   -D Trilinos_ENABLE_EXPLICIT_INSTANTIATION=ON \
   -D Trilinos_ENABLE_FLOAT=ON \


### PR DESCRIPTION
#432 does not work for me when I compile trilinos 17. This is related to the following change: https://github.com/trilinos/Trilinos/blob/master/RELEASE_NOTES#L168. I do not quite know what to make of this. Does this mean trilinos requires gtest by default, and in previous releases they shipped it as in source package, but starting with 17 they require it as external third-party library?

I get the following error with candi master:
```
Processing enabled external package/TPL: gtest (enabled by MiniTensor, disable with -DTPL_ENABLE_gtest=OFF)
-- Using find_package(GTest ...) ...
-- Could NOT find GTest (missing: GTEST_LIBRARY GTEST_INCLUDE_DIR GTEST_MAIN_LIBRARY) 
-- gtest_LIBRARY_NAMES='gtest googletest'
-- Must find at least one lib in each of the lib sets "gtest googletest"
-- Searching for libs in gtest_LIBRARY_DIRS=''
-- Searching for a lib in the set "gtest googletest":
--   Searching for lib 'gtest' ...
--   Searching for lib 'googletest' ...
-- ERROR: Did not find a lib in the lib set "gtest googletest" for the TPL 'gtest'!
-- ERROR: Could not find the libraries for the TPL 'gtest'!
-- TIP: If the TPL 'gtest' is on your system then you can set:
     -Dgtest_LIBRARY_DIRS='<dir0>;<dir1>;...'
   to point to the directories where these libraries may be found.
   Or, just set:
     -DTPL_gtest_LIBRARIES='<path-to-libs0>;<path-to-libs1>;...'
   to point to the full paths for the libraries which will
   bypass any search for libraries and these libraries will be used without
   question in the build.  (But this will result in a build-time error
   if not all of the necessary symbols are found.)
-- ERROR: Failed finding all of the parts of TPL 'gtest' (see above), Aborting!

-- NOTE: The find module file for this failed TPL 'gtest' is:
     /home/rene/software/deal.II-tpetra/tmp/unpack/Trilinos-trilinos-release-17-0-0/cmake/TPLs/FindTPLgtest.cmake
   which is pointed to in the file:
     /home/rene/software/deal.II-tpetra/tmp/unpack/Trilinos-trilinos-release-17-0-0/TPLsList.cmake

TIP: One way to get past the configure failure for the
TPL 'gtest' is to simply disable it with:
  -DTPL_ENABLE_gtest=OFF
which will disable it and will recursively disable all of the
downstream packages that have required dependencies on it, including
the package 'MiniTensor' which triggered its enable.
When you reconfigure, just grep the cmake stdout for 'gtest'
and then follow the disables that occur as a result to see what impact
this TPL disable has on the configuration of Trilinos.

CMake Error at cmake/tribits/core/package_arch/TribitsProcessEnabledTpls.cmake:248 (message):
  ERROR: TPL_gtest_NOT_FOUND=TRUE, aborting!
Call Stack (most recent call first):
  cmake/tribits/core/package_arch/TribitsProcessEnabledTpls.cmake:141 (tribits_address_failed_tpl_find)
  cmake/tribits/core/package_arch/TribitsProcessEnabledTpls.cmake:75 (tribits_process_enabled_standard_tpl)
  cmake/tribits/core/package_arch/TribitsProjectImpl.cmake:169 (tribits_process_enabled_tpls)
  cmake/tribits/core/package_arch/TribitsProject.cmake:62 (tribits_project_impl)
  CMakeLists.txt:48 (TRIBITS_PROJECT)


-- Configuring incomplete, errors occurred!
Failure with exit status: 1
Exit message: There was a problem configuring trilinos 17-0-0.
```

The attached PR fixes the issue by picking the spelling depending on the trilinos version.

Since it is a testing library, it presumably is not necessary for us, as long as we dont want to run the trilinos tests.