### PR TITLE
Configure Trilinos thread-safe

### DIFF
--- a/deal.II-toolchain/packages/trilinos.package
+++ b/deal.II-toolchain/packages/trilinos.package
@@ -287,6 +287,7 @@ CONFOPTS="\
   -D Trilinos_VERBOSE_CONFIGURE:BOOL=OFF \
   -D Trilinos_ENABLE_EXPLICIT_INSTANTIATION=ON \
   -D Trilinos_ENABLE_FLOAT=ON \
+  -D Trilinos_ENABLE_THREAD_SAFE=ON \
   -D Trilinos_ENABLE_Amesos:BOOL=ON \
   -D Trilinos_ENABLE_Epetra:BOOL=ON \
   -D Trilinos_ENABLE_EpetraExt:BOOL=ON \


### PR DESCRIPTION
As discussed in dealii/dealii#19867 and dealii/dealii#19887 the reference-counted pointer classes of Trilinos (Teuchos) are not safe in thread-parallel code by default, but we make use of thread-parallelism to access vectors and matrices. dealii/dealii#19867 is a workaround, but reduces performance during assembly a bit. We should therefore ensure as many users as possible use Trilinos in a thread-safe configuration (the performance penalty of this is much smaller in my profiling).